### PR TITLE
Ports Renaming Pens

### DIFF
--- a/code/modules/paperwork/pen.dm
+++ b/code/modules/paperwork/pen.dm
@@ -33,6 +33,13 @@
 	sharpness = SHARP_POINTY
 	var/naming = FALSE
 
+/obj/item/pen/examine(mob/user)
+	. = ..()
+	if(naming)
+		. += span_notice("Currently renaming things! Alt-click to disable renaming mode!")
+	else
+		. += span_notice("Alt-click to enable renaming mode!")
+
 /obj/item/pen/suicide_act(mob/user)
 	user.visible_message(span_suicide("[user] is scribbling numbers all over [user.p_them()]self with [src]! It looks like [user.p_theyre()] trying to commit sudoku..."))
 	return(BRUTELOSS)

--- a/code/modules/paperwork/pen.dm
+++ b/code/modules/paperwork/pen.dm
@@ -40,6 +40,22 @@
 	else
 		. += span_notice("Alt-click to enable renaming mode!")
 
+/obj/item/pen/AltClick(mob/user)
+	if(!naming)
+		naming = TRUE
+		w_class = WEIGHT_CLASS_GIGANTIC
+		sharpness = SHARP_NONE
+		to_chat(usr, "<span class='notice'>You firmly grip the pen in preparation to rename something.</span>")
+		playsound(src, 'sound/machines/button2.ogg', 100, 1)
+		return
+	if(naming)
+		naming = FALSE
+		w_class = WEIGHT_CLASS_TINY
+		sharpness = SHARP_POINTY
+		to_chat(usr, "<span class='notice'>You reset the grip on the pen</span>")
+		playsound(src, 'sound/machines/button2.ogg', 100, 1)
+		return
+
 /obj/item/pen/suicide_act(mob/user)
 	user.visible_message(span_suicide("[user] is scribbling numbers all over [user.p_them()]self with [src]! It looks like [user.p_theyre()] trying to commit sudoku..."))
 	return(BRUTELOSS)

--- a/code/modules/paperwork/pen.dm
+++ b/code/modules/paperwork/pen.dm
@@ -31,6 +31,7 @@
 	var/font = PEN_FONT
 	embedding = list()
 	sharpness = SHARP_POINTY
+	var/naming = FALSE
 
 /obj/item/pen/suicide_act(mob/user)
 	user.visible_message(span_suicide("[user] is scribbling numbers all over [user.p_them()]self with [src]! It looks like [user.p_theyre()] trying to commit sudoku..."))
@@ -145,32 +146,35 @@
 	else
 		. = ..()
 
-/obj/item/pen/afterattack(obj/O, mob/living/user, proximity)
+
+/obj/item/pen/afterattack(obj/O, mob/living/user, proximity, params)
 	. = ..()
-	//Changing Name/Description of items. Only works if they have the 'unique_rename' flag set
-	if(isobj(O) && proximity && (O.obj_flags & UNIQUE_RENAME))
-		var/penchoice = input(user, "What would you like to edit?", "Rename or change description?") as null|anything in list("Rename","Change description")
-		if(QDELETED(O) || !user.canUseTopic(O, BE_CLOSE))
-			return
-		if(penchoice == "Rename")
-			var/input = stripped_input(user,"What do you want to name \the [O.name]?", ,"", MAX_NAME_LEN)
-			var/oldname = O.name
+	if (naming)
+		//Changing Name/Description of items. Only works if they have the 'unique_rename' flag set
+		if(isobj(O) && proximity)
+			var/penchoice = input(user, "What would you like to edit?", "Rename or change description?") as null|anything in list("Rename","Change description")
 			if(QDELETED(O) || !user.canUseTopic(O, BE_CLOSE))
 				return
-			if(oldname == input)
-				to_chat(user, span_notice("You changed \the [O.name] to... well... \the [O.name]."))
-			else
-				O.name = input
-				to_chat(user, span_notice("\The [oldname] has been successfully been renamed to \the [input]."))
-				O.renamedByPlayer = TRUE
+			if(penchoice == "Rename")
+				var/input = stripped_input(user,"What do you want to name \the [O.name]?", ,"", MAX_NAME_LEN)
+				var/oldname = O.name
+				if(QDELETED(O) || !user.canUseTopic(O, BE_CLOSE))
+					return
+				if(oldname == input)
+					to_chat(user, "<span class='notice'>You changed \the [O.name] to... well... \the [O.name].</span>")
+				else
+					O.name = input
+					to_chat(user, "<span class='notice'>\The [oldname] has been successfully been renamed to \the [input].</span>")
+					O.renamedByPlayer = TRUE
 
-		if(penchoice == "Change description")
-			var/input = stripped_input(user,"Describe \the [O.name] here", ,"", 100)
-			if(QDELETED(O) || !user.canUseTopic(O, BE_CLOSE))
-				return
-			O.desc = input
-			to_chat(user, span_notice("You have successfully changed \the [O.name]'s description."))
-
+			if(penchoice == "Change description")
+				var/input = stripped_input(user,"Describe \the [O.name] here", ,"", 100)
+				if(QDELETED(O) || !user.canUseTopic(O, BE_CLOSE))
+					return
+				O.desc = input
+				to_chat(user, "<span class='notice'>You have successfully changed \the [O.name]'s description.</span>")
+	else	
+		return
 /*
  * Sleepypens
  */


### PR DESCRIPTION
## About The Pull Request
Due to this being an ooold fork of coyote code, we lack renaming pens. This fixes that!
Most servers from wasteland onward at the least had some variant of renaming mode with pens. This ports it from coyote which ported it from atom bomb.

Allows for greater customization (Tribalized fire-bows or lamp-torches) and roleplay (renaming a capgun to a .38 special, selling it to a player for 40 caps)

## Pre-Merge Checklist
- [ ] You tested this on a local server.
- [ ] This code did not runtime during testing.
- [ ] You documented all of your changes.
<!-- Tick these after making the PR. -->

## Changelog
:cl:
add: Added renaming pens
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
