### PR TITLE
Fixes Compost Stats

### DIFF
--- a/code/modules/farming/farming_structures.dm
+++ b/code/modules/farming/farming_structures.dm
@@ -164,14 +164,14 @@
 	pass_flags_self = PASSTABLE | LETPASSTHROW
 	climbable = TRUE
 	var/seed_default_value = 4
-	var/seed_to_compost_scale = 0.08 // Meaning average (50 potency) foods will give 4 compost
+	var/seed_to_compost_scale = 0.16 // Meaning average (50 potency) foods will give 8 compost
 	var/produce_default_value = 10
-	var/food_to_compost_scale = 0.2 // Meaning average (50 potency) foods will give 10 compost
+	var/food_to_compost_scale = 0.25 // Meaning average (50 potency) foods will give 15 compost
 
 /obj/structure/reagent_dispensers/compostbin/Initialize()
 	. = ..()
 	reagents.clear_reagents()
-	reagents.add_reagent(reagent_id, 100)
+	reagents.add_reagent(reagent_id, 1000)
 
 /obj/structure/reagent_dispensers/compostbin/attackby(obj/item/W, mob/user, params)
 	if(W.is_refillable())


### PR DESCRIPTION
## About The Pull Request
Makes it so compost bins have 1,000 starting nutrient instead of 100, also makes stuff compost into more nutrients due to complaints of nutrient drian rate.

## Pre-Merge Checklist
- [ ] You tested this on a local server.
- [ ] This code did not runtime during testing.
- [ ] You documented all of your changes.
<!-- Tick these after making the PR. -->

## Changelog
:cl:
tweaks: Adjusts values on initializing compost bins to 1,000 instead of 100 - also makes it so recycling food and seeds is roughly doubled.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
