### PR TITLE
Updating/Fixing Initiate Loadout

### DIFF
--- a/code/modules/jobs/job_types/bos.dm
+++ b/code/modules/jobs/job_types/bos.dm
@@ -1183,8 +1183,8 @@ Initiate
 
 /datum/outfit/loadout/initiatek
 	name = "Knight-Aspirant"
-	belt = 			/obj/item/storage/belt/utility
-	suit = 			/obj/item/clothing/suit/armor/light/duster/bos/outcast
+	belt = 			/obj/item/storage/belt/army/assault
+	suit = 			/obj/item/clothing/suit/armor/medium/combat/brotherhood/initiate
 	head = 			/obj/item/clothing/head/helmet/f13/combat/brotherhood/initiate
 	backpack_contents = list(
 		/obj/item/gun/energy/laser/wattz=1,


### PR DESCRIPTION
## About The Pull Request
A simple fix for the Brotherhood of Steel Initiate loadout. Giving the Initiate Knight Aspirant loadout option back their armour (instead of a random duster) alongside a proper belt. Upon speaking with TEF and Rebel, it was made known that Initiates (Knight Aspirant) shouldn't have had those dusters and should have had their Initiate armour to match the Initiate helmet they had already received.

## Pre-Merge Checklist
- [ ] You tested this on a local server.
- [ ] This code did not runtime during testing.
- [ ] You documented all of your changes.
<!-- Tick these after making the PR. -->

## Changelog
:cl:
tweak: Changed Initiate (Knight Aspirant) Duster to Initiate Armor
tweak: Changed Initiate (Knight Aspirant) Utility Belt to Military belt
/:cl:

