### PR TITLE
Replaces Subtle Emotes with simply Anti-Ghost Emotes

### DIFF
--- a/code/modules/keybindings/keybind/communication.dm
+++ b/code/modules/keybindings/keybind/communication.dm
@@ -42,17 +42,11 @@
 	M.me_typing_indicator()
 	return TRUE
 
-/datum/keybinding/client/communication/subtle
-	hotkey_keys = list("5")
-	name = "Subtle"
-	full_name = "Subtle Emote"
-	clientside = "subtle"
-
 /datum/keybinding/client/communication/subtler
-	hotkey_keys = list("6")
+	hotkey_keys = list("5")
 	name = "Subtler"
-	full_name = "Subtler Anti-Ghost Emote"
-	clientside = "subtler-anti-ghost"
+	full_name = "Me (emote - Antighost)"
+	clientside = "me (antighost)"
 
 /datum/keybinding/client/communication/whisper
 	hotkey_keys = list("Y")

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -9,7 +9,6 @@
 	add_verb(src, /mob/living/proc/mob_sleep)
 	add_verb(src, /mob/living/proc/lay_down)
 	add_verb(src, /mob/living/carbon/human/verb/underwear_toggle)
-	add_verb(src, /mob/living/verb/subtle)
 	add_verb(src, /mob/living/verb/subtler)
 	add_verb(src, /mob/living/verb/try_to_talk_to)
 	//initialize limbs first

--- a/code/modules/mob/say_vr.dm
+++ b/code/modules/mob/say_vr.dm
@@ -85,7 +85,7 @@ proc/get_top_level_mob(mob/S)
 		message = message,
 		blind_message = message,
 		self_message = message,
-		vision_distance = 1,
+		vision_distance = 7,
 		ignored_mobs = non_admin_ghosts)
 
 	//broadcast to ghosts, if they have a client, are dead, arent in the lobby, allow ghostsight, and, if subtler, are admemes
@@ -93,6 +93,7 @@ proc/get_top_level_mob(mob/S)
 
 
 ///////////////// VERB CODE
+/*
 /mob/living/proc/subtle_keybind()
 	var/message = input(src, "", "subtle") as text|null
 	if(!length(message))
@@ -106,10 +107,10 @@ proc/get_top_level_mob(mob/S)
 		to_chat(usr, span_danger("Speech is currently admin-disabled."))
 		return
 	usr.emote("subtle")
-
+*/
 ///////////////// VERB CODE 2
 /mob/living/verb/subtler()
-	set name = "Subtler Anti-Ghost"
+	set name = "Anti-Ghost Emote"
 	set category = "IC"
 	if(GLOB.say_disabled)	//This is here to try to identify lag problems
 		to_chat(usr, span_danger("Speech is currently admin-disabled."))


### PR DESCRIPTION
## About The Pull Request
Basically removes the subtle emote and instead makes subtler the standard. This also extends the range of these emotes to 7 tiles (normal screen-length), but keeps it invisible to ghosts besides admins.

Why? A few reasons listed here:
1. **Subtle emotes have a larger range because they are, at times, used for meta purposes**, be it for sessions of public ERP or people attempting to whisper while generating no visible logs to other players. Such as planning to esc or jump someone without any means of even knowing communication is happening. These emotes will remain only visible to admin ghost and not regular ghosts however, meaning ERP scenes won't flashbang ghosts in dead chat and scenes using this emote will remain private in such a manner.
2. **Subtle and Subtler make little sense as separate emotes.** Why subtle emote but allow ghosts to see verses subtler and only make it so the person next to you or on your tile can see? It is a relatively pointless difference which I can't think of an exact use of besides exhibitionism for ghosts. Which.. I don't know why you wouldn't just me-emote at that point or something along those lines.

## Pre-Merge Checklist
- [ ] You tested this on a local server.
- [ ] This code did not runtime during testing.
- [ ] You documented all of your changes.
<!-- Tick these after making the PR. -->

## Changelog
:cl:
removes: Subtle emotes (Not to be mistaken with subtler / anti-ghost; that has remained.)
tweaks: Tweaks range of subtler emotes to 7 tiles, the range of a normal me-emote. (These emotes remain invisible to ghosts; this is to avoid abuse of emotes for public ERP or to otherwise attempt to 'powergame' / 'metagame')
/:cl:
