### PR TITLE
Updates the timer subsystem and adds compat procs

### DIFF
--- a/code/__byond_version_compat.dm
+++ b/code/__byond_version_compat.dm
@@ -1,0 +1,44 @@
+// This file contains defines allowing targeting byond versions newer than the supported
+//Update this whenever you need to take advantage of more recent byond features
+#define MIN_COMPILER_VERSION 513
+#define MIN_COMPILER_BUILD 1514
+#if DM_VERSION < MIN_COMPILER_VERSION || DM_BUILD < MIN_COMPILER_BUILD
+//Don't forget to update this part
+#error Your version of BYOND is too out-of-date to compile this project. Go to https://secure.byond.com/download and update.
+#error You need version 513.1508 or higher
+#endif
+
+#if DM_VERSION == 514 && DM_BUILD >= 1585
+#warn You are using BYOND 514.1585. There's a good chance that Auxtools will cause the project to compile incorrectly.area
+#warn You can download an earlier version of BYOND from https://www.byond.com/download/build/514, if it doesn't work.
+#endif // If this is fixed after 514.1585, please remove this warning.
+
+#if DM_BUILD < 1540
+#define AS as()
+#else
+#define AS as anything
+#endif
+
+// So we want to have compile time guarantees these procs exist on local type, unfortunately 515 killed the .proc/procname syntax so we have to use nameof()
+#if DM_VERSION < 515
+/// Call by name proc reference, checks if the proc exists on this type or as a global proc
+#define PROC_REF(X) (.proc/##X)
+/// Call by name proc reference, checks if the proc exists on given type or as a global proc
+#define TYPE_PROC_REF(TYPE, X) (##TYPE.proc/##X)
+/// Call by name proc reference, checks if the proc is existing global proc
+#define GLOBAL_PROC_REF(X) (/proc/##X)
+#else
+/// Call by name proc reference, checks if the proc exists on this type or as a global proc
+#define PROC_REF(X) (nameof(.proc/##X))
+/// Call by name proc reference, checks if the proc exists on given type or as a global proc
+#define TYPE_PROC_REF(TYPE, X) (nameof(##TYPE.proc/##X))
+/// Call by name proc reference, checks if the proc is existing global proc
+#define GLOBAL_PROC_REF(X) (/proc/##X)
+#endif
+
+// 515 split call for external libraries into call_ext
+#if DM_VERSION < 515
+#define LIBCALL call
+#else
+#define LIBCALL call_ext
+#endif

--- a/code/_compile_options.dm
+++ b/code/_compile_options.dm
@@ -64,20 +64,6 @@
 #define FORCE_MAP "_maps/runtimestation.json"
 #endif
 
-//Update this whenever you need to take advantage of more recent byond features
-#define MIN_COMPILER_VERSION 513
-#define MIN_COMPILER_BUILD 1514
-#if DM_VERSION < MIN_COMPILER_VERSION || DM_BUILD < MIN_COMPILER_BUILD
-//Don't forget to update this part
-#error Your version of BYOND is too out-of-date to compile this project. Go to https://secure.byond.com/download and update.
-#error You need version 513.1508 or higher
-#endif
-
-#if DM_VERSION == 514 && DM_BUILD >= 1585
-#warn You are using BYOND 514.1585. There's a good chance that Auxtools will cause the project to compile incorrectly.area
-#warn You can download an earlier version of BYOND from https://www.byond.com/download/build/514, if it doesn't work.
-#endif // If this is fixed after 514.1585, please remove this warning.
-
 //Additional code for the above flags.
 #ifdef TESTING
 #warn compiling in TESTING mode. testing() debug messages will be visible.

--- a/code/controllers/subsystem/timer.dm
+++ b/code/controllers/subsystem/timer.dm
@@ -1,7 +1,7 @@
 /// Controls how many buckets should be kept, each representing a tick. (1 minutes worth)
 #define BUCKET_LEN (world.fps*1*60)
 /// Helper for getting the correct bucket for a given timer
-#define BUCKET_POS(timer) (((ROUND_UP((timer.timeToRun - timer.timer_subsystem.head_offset) / world.tick_lag)+1) % BUCKET_LEN)||BUCKET_LEN)
+#define BUCKET_POS(timer) (((ROUND_UP((timer.timeToRun - timer.timer_subsystem.head_offset) / world.tick_lag)+1) % BUCKET_LEN) || BUCKET_LEN)
 /// Gets the maximum time at which timers will be invoked from buckets, used for deferring to secondary queue
 #define TIMER_MAX(timer_ss) (timer_ss.head_offset + TICKS2DS(BUCKET_LEN + timer_ss.practical_offset - 1))
 /// Max float with integer precision
@@ -127,7 +127,9 @@ SUBSYSTEM_DEF(timer)
 		ctime_timer.spent = REALTIMEOFDAY
 		callBack.InvokeAsync()
 
-		if(ctime_timer.flags & TIMER_LOOP)
+		if(ctime_timer.flags & TIMER_LOOP) // Re-insert valid looping client timers into the client timer list.
+			if (QDELETED(ctime_timer)) // Don't re-insert timers deleted inside their callbacks.
+				continue
 			ctime_timer.spent = 0
 			ctime_timer.timeToRun = REALTIMEOFDAY + ctime_timer.wait
 			BINARY_INSERT(ctime_timer, clienttime_timers, /datum/timedevent, ctime_timer, timeToRun, COMPARE_KEY)
@@ -173,7 +175,9 @@ SUBSYSTEM_DEF(timer)
 				callBack.InvokeAsync()
 				last_invoke_tick = world.time
 
-			if (timer.flags & TIMER_LOOP) // Prepare looping timers to re-enter the queue
+			if (timer.flags & TIMER_LOOP) // Prepare valid looping timers to re-enter the queue
+				if(QDELETED(timer)) // If a loop is deleted in its callback, we need to avoid re-inserting it.
+					continue
 				timer.spent = 0
 				timer.timeToRun = world.time + timer.wait
 				timer.bucketJoin()
@@ -273,7 +277,7 @@ SUBSYSTEM_DEF(timer)
 		return
 
 	// Sort all timers by time to run
-	sortTim(alltimers, .proc/cmp_timer)
+	sortTim(alltimers, GLOBAL_PROC_REF(cmp_timer))
 
 	// Get the earliest timer, and if the TTR is earlier than the current world.time,
 	// then set the head offset appropriately to be the earliest time tracked by the
@@ -501,8 +505,8 @@ SUBSYSTEM_DEF(timer)
 /datum/timedevent/proc/bucketJoin()
 	// Generate debug-friendly name for timer
 	var/static/list/bitfield_flags = list("TIMER_UNIQUE", "TIMER_OVERRIDE", "TIMER_CLIENT_TIME", "TIMER_STOPPABLE", "TIMER_NO_HASH_WAIT", "TIMER_LOOP")
-	name = "Timer: [id] (\ref[src]), TTR: [timeToRun], wait:[wait] Flags: [jointext(bitfield_to_list(flags, bitfield_flags), ", ")], \
-		callBack: \ref[callBack], callBack.object: [callBack.object]\ref[callBack.object]([getcallingtype()]), \
+	name = "Timer: [id] ([\ref(src)]), TTR: [timeToRun], wait:[wait] Flags: [jointext(bitfield_to_list(flags, bitfield_flags), ", ")], \
+		callBack: [\ref(callBack)], callBack.object: [callBack.object][\ref(callBack.object)]([getcallingtype()]), \
 		callBack.delegate:[callBack.delegate]([callBack.arguments ? callBack.arguments.Join(", ") : ""]), source: [source]"
 
 	if (bucket_joined)
@@ -565,6 +569,7 @@ SUBSYSTEM_DEF(timer)
  * * callback the callback to call on timer finish
  * * wait deciseconds to run the timer for
  * * flags flags for this timer, see: code\__DEFINES\subsystems.dm
+ * * timer_subsystem the subsystem to insert this timer into
  */
 /proc/_addtimer(datum/callback/callback, wait = 0, flags = 0, datum/controller/subsystem/timer/timer_subsystem, file, line)
 	if (!callback)
@@ -577,7 +582,10 @@ SUBSYSTEM_DEF(timer)
 		stack_trace("addtimer called with a callback assigned to a qdeleted object. In the future such timers will not \
 			be supported and may refuse to run or run with a 0 wait")
 
-	wait = max(CEILING(wait, world.tick_lag), world.tick_lag)
+	if (flags & TIMER_CLIENT_TIME) // REALTIMEOFDAY has a resolution of 1 decisecond
+		wait = max(CEILING(wait, 1), 1) // so if we use tick_lag timers may be inserted in the "past"
+	else
+		wait = max(CEILING(wait, world.tick_lag), world.tick_lag)
 
 	if(wait >= INFINITY)
 		CRASH("Attempted to create timer with INFINITY delay")
@@ -606,7 +614,7 @@ SUBSYSTEM_DEF(timer)
 						. = hash_timer.id
 					return
 	else if(flags & TIMER_OVERRIDE)
-		stack_trace("TIMER_OVERRIDE used without TIMER_UNIQUE")
+		stack_trace("TIMER_OVERRIDE used without TIMER_UNIQUE") //this is also caught by grep.
 
 	var/datum/timedevent/timer = new(callback, wait, flags, timer_subsystem, hash, file && "[file]:[line]")
 	return timer.id
@@ -655,28 +663,30 @@ SUBSYSTEM_DEF(timer)
 	return timer.timeToRun - (timer.flags & TIMER_CLIENT_TIME ? REALTIMEOFDAY : world.time)
 
 /**
- * Set the wait time on a timer, mostly just useful for 
+ * Update the delay on an existing LOOPING timer
+ * Will come into effect on the next process
  *
  * Arguments:
  * * id a timerid or a /datum/timedevent
- * * wait a new time to set the timer
+ * * new_wait the new wait to give this looping timer
  */
-/proc/set_timer_wait(id, wait = 0, datum/controller/subsystem/timer/timer_subsystem)
+/proc/updatetimedelay(id, new_wait, datum/controller/subsystem/timer/timer_subsystem)
 	if (!id)
-		return null
+		return
 	if (id == TIMER_ID_NULL)
-		CRASH("Tried to get timeleft of a null timerid. Use TIMER_STOPPABLE flag")
+		CRASH("Tried to update the wait of null timerid. Use TIMER_STOPPABLE flag")
 	if (istype(id, /datum/timedevent))
 		var/datum/timedevent/timer = id
-		timer.wait = wait
-		return timer.wait
+		timer.wait = new_wait
+		return
 	timer_subsystem = timer_subsystem || SStimer
 	//id is string
 	var/datum/timedevent/timer = timer_subsystem.timer_id_dict[id]
-	if(!timer)
-		return null
-	timer.wait = wait
-	return timer.wait
+	if(!timer || timer.spent)
+		return
+	if(!(timer.flags & TIMER_LOOP))
+		CRASH("Tried to update the wait of a non looping timer. This is not supported")
+	timer.wait = new_wait
 
 #undef BUCKET_LEN
 #undef BUCKET_POS

--- a/code/datums/looping_sounds/_looping_sound.dm
+++ b/code/datums/looping_sounds/_looping_sound.dm
@@ -96,7 +96,7 @@
 	if(!timerid)
 		timerid = addtimer(CALLBACK(src, .proc/sound_loop, world.time), mid_length + loop_delay, TIMER_CLIENT_TIME | TIMER_STOPPABLE | TIMER_LOOP)
 	else
-		set_timer_wait(timerid, mid_length + loop_delay)
+		updatetimedelay(timerid, mid_length + loop_delay)
 
 /// takes in list('sound/file.ogg', mid_length) and plays the file and ques up another in mid_length deciseconds
 /datum/looping_sound/proc/play(list/sound_list)

--- a/code/datums/materials/_material.dm
+++ b/code/datums/materials/_material.dm
@@ -56,7 +56,7 @@ Simple datum which is instanced once per type and is used for every object of sa
 		source.name = "[name] [source.name]"
 
 	if(beauty_modifier)
-		addtimer(CALLBACK(source, /datum.proc/_AddElement, list(/datum/element/beauty, beauty_modifier * amount)), 0)
+		source.AddElement(/datum/element/beauty, beauty_modifier * amount)
 
 	if(istype(source, /obj)) //objs
 		on_applied_obj(source, amount, material_flags)

--- a/code/game/objects/effects/decals/cleanable.dm
+++ b/code/game/objects/effects/decals/cleanable.dm
@@ -32,7 +32,9 @@
 	)
 	AddElement(/datum/element/connect_loc, loc_connections)
 
-	addtimer(CALLBACK(src, /datum.proc/_AddElement, list(/datum/element/beauty, beauty)), 0)
+/obj/effect/decal/cleanable/LateInitialize()
+	. = ..()
+	AddElement(/datum/element/beauty, beauty)
 
 /obj/effect/decal/cleanable/proc/replace_decal(obj/effect/decal/cleanable/C) // Returns true if we should give up in favor of the pre-existing decal
 	if(mergeable_decal)

--- a/code/game/objects/items/melee/weaponry.dm
+++ b/code/game/objects/items/melee/weaponry.dm
@@ -436,7 +436,10 @@ for further reading, please see: https://github.com/tgstation/tgstation/pull/301
 /obj/item/statuebust/Initialize()
 	. = ..()
 	AddElement(/datum/element/art, impressiveness)
-	addtimer(CALLBACK(src, /datum.proc/_AddElement, list(/datum/element/beauty, 1000)), 0)
+
+/obj/item/statuebust/LateInitialize()
+	. = ..()
+	AddElement(/datum/element/beauty, 1000)
 
 /obj/item/tailclub
 	name = "tail club"

--- a/code/game/objects/structures/beds_chairs/chair.dm
+++ b/code/game/objects/structures/beds_chairs/chair.dm
@@ -24,9 +24,12 @@
 
 /obj/structure/chair/Initialize()
 	. = ..()
-	if(!anchored)	//why would you put these on the shuttle?
-		addtimer(CALLBACK(src, .proc/RemoveFromLatejoin), 0)
 	handle_layer()
+
+/obj/structure/chair/LateInitialize()
+	. = ..()
+	if(!anchored)	//this is probably not necesarry
+		addtimer(CALLBACK(src, .proc/RemoveFromLatejoin), 0)
 
 /obj/structure/chair/ComponentInitialize()
 	. = ..()

--- a/code/game/objects/structures/crates_lockers/closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets.dm
@@ -51,11 +51,13 @@
 		PopulateContents()
 	if(anchored)
 		storage_capacity = 30
-	if(mapload && !opened)		// if closed, any item at the crate's loc is put in the contents
-		addtimer(CALLBACK(src, .proc/take_contents), 0)
 	if(secure)
 		lockerelectronics = new(src)
 		lockerelectronics.accesses = req_access
+
+/obj/structure/closet/LateInitialize()
+	. = ..()
+	take_contents()
 
 //USE THIS TO FILL IT, NOT INITIALIZE OR NEW
 /obj/structure/closet/proc/PopulateContents()

--- a/code/game/objects/structures/flora.dm
+++ b/code/game/objects/structures/flora.dm
@@ -335,8 +335,11 @@
 /obj/item/kirbyplants/ComponentInitialize()
 	. = ..()
 	AddElement(/datum/element/tactical)
-	addtimer(CALLBACK(src, /datum.proc/_AddElement, list(/datum/element/beauty, 500)), 0)
 	AddComponent(/datum/component/two_handed, require_twohands=TRUE, force_unwielded=10, force_wielded=10)
+
+/obj/item/kirbyplants/LateInitialize()
+	. = ..()
+	AddElement(/datum/element/beauty, 500)
 
 /obj/item/kirbyplants/random
 	icon = 'icons/obj/flora/_flora.dmi'

--- a/code/game/objects/structures/statues.dm
+++ b/code/game/objects/structures/statues.dm
@@ -15,8 +15,11 @@
 /obj/structure/statue/Initialize()
 	. = ..()
 	AddElement(/datum/element/art, impressiveness)
-	addtimer(CALLBACK(src, /datum.proc/_AddElement, list(/datum/element/beauty, impressiveness *  75)), 0)
 	AddComponent(/datum/component/simple_rotation, ROTATION_ALTCLICK | ROTATION_CLOCKWISE, CALLBACK(src, .proc/can_user_rotate), CALLBACK(src, .proc/can_be_rotated), null)
+
+/obj/structure/statue/LateInitialize()
+	. = ..()
+	AddElement(/datum/element/beauty, impressiveness * 75)
 
 /obj/structure/statue/proc/can_be_rotated(mob/user)
 	if(!anchored)

--- a/code/modules/holodeck/computer.dm
+++ b/code/modules/holodeck/computer.dm
@@ -61,8 +61,8 @@
 		log_world("No matching holodeck area found")
 		qdel(src)
 		return
-	var/area/AS = get_area(src)
-	if(istype(AS, /area/holodeck))
+	var/area/current_area = get_area(src)
+	if(istype(current_area, /area/holodeck))
 		log_mapping("Holodeck computer cannot be in a holodeck, This would cause circular power dependency.")
 		qdel(src)
 		return
@@ -322,8 +322,8 @@
 
 /obj/machinery/computer/holodeck/virtual/derez(obj/O, silent = TRUE, forced = FALSE)
 	// We don't want to ever despawn things that got out of the holodeck area in this case
-	var/area/AS = get_area(O)
-	if(!istype(AS, /area/holodeck))
+	var/area/current_area = get_area(O)
+	if(!istype(current_area, /area/holodeck))
 		return
 
 	if(O && !stat && !forced)

--- a/code/modules/mob/living/silicon/pai/pai.dm
+++ b/code/modules/mob/living/silicon/pai/pai.dm
@@ -122,14 +122,14 @@
 	. = ..()
 
 	var/datum/action/innate/pai/software/SW = new
-	var/datum/action/innate/pai/shell/AS = new /datum/action/innate/pai/shell
+	var/datum/action/innate/pai/shell/pai_shell = new /datum/action/innate/pai/shell
 	var/datum/action/innate/pai/chassis/AC = new /datum/action/innate/pai/chassis
 	var/datum/action/innate/pai/rest/AR = new /datum/action/innate/pai/rest
 	var/datum/action/innate/pai/light/AL = new /datum/action/innate/pai/light
 
 	var/datum/action/language_menu/ALM = new
 	SW.Grant(src)
-	AS.Grant(src)
+	pai_shell.Grant(src)
 	AC.Grant(src)
 	AR.Grant(src)
 	AL.Grant(src)

--- a/fortune13.dme
+++ b/fortune13.dme
@@ -15,6 +15,7 @@
 
 // BEGIN_INCLUDE
 #include "_maps\_basemap.dm"
+#include "code\__byond_version_compat.dm"
 #include "code\_compile_options.dm"
 #include "code\world.dm"
 #include "code\__DEFINES\_auxtools.dm"

--- a/modular_citadel/code/modules/reagents/chemistry/reagents/astrogen.dm
+++ b/modular_citadel/code/modules/reagents/chemistry/reagents/astrogen.dm
@@ -29,7 +29,7 @@ I'd like to point out from my calculations it'll take about 60-80 minutes to die
 	var/sleepytime = 0
 	inverse_chem_val = 0.25
 	can_synth = FALSE
-	var/datum/action/chem/astral/AS = new/datum/action/chem/astral()
+	var/datum/action/chem/astral/astral_chem = new/datum/action/chem/astral()
 	value = REAGENT_VALUE_AMAZING
 
 /datum/action/chem/astral
@@ -73,9 +73,9 @@ I'd like to point out from my calculations it'll take about 60-80 minutes to die
 			G = new(get_turf(M.loc))
 		G.name = "[M]'s astral projection"
 		//var/datum/action/chem/astral/AS = new(G)
-		AS.Grant(G)
-		AS.origin = M
-		AS.originalmind = originalmind
+		astral_chem.Grant(G)
+		astral_chem.origin = M
+		astral_chem.originalmind = originalmind
 
 		if(M.mind)
 			M.mind.transfer_to(G)


### PR DESCRIPTION
## About The Pull Request
<!-- Write here -->

Moves the compat checking defines into a seperate files, adds the 515 compat defines ahead of time.
Also addresses a bunch of 0 second timers.
Updates the timer subsystem to tg's.

## Pre-Merge Checklist
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
<!-- Tick these after making the PR. -->

## Changelog
:cl:
code: Moved the compat checking defines into a seperate files, adds the 515 compat defines ahead of time
code: Updated the timer subsystem
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
