### PR TITLE
Adds two energy guns to the premium weapon list

### DIFF
--- a/code/game/objects/items/loadout_beacons.dm
+++ b/code/game/objects/items/loadout_beacons.dm
@@ -1104,6 +1104,18 @@ GLOBAL_LIST_EMPTY(loadout_boxes)
 	entry_class = LOADOUT_CAT_LAWMAN
 	spawn_thing = /obj/item/storage/box/gun/premium/desert_ranger
 
+/datum/loadout_box/wattz_2000s
+	entry_tag = "wattz 2000s"
+	entry_flags = LOADOUT_FLAG_LAWMAN
+	entry_class = LOADOUT_CAT_LAWMAN
+	spawn_thing = /obj/item/gun/energy/laser/wattz2ks
+
+/datum/loadout_box/rcw
+	entry_tag = "laser RCW"
+	entry_flags = LOADOUT_FLAG_LAWMAN
+	entry_class = LOADOUT_CAT_LAWMAN
+	spawn_thing = /obj/item/gun/energy/laser/rcw
+
 /// Lawman guns
 
 /datum/loadout_box/american_180

--- a/code/game/objects/items/loadout_beacons.dm
+++ b/code/game/objects/items/loadout_beacons.dm
@@ -1104,11 +1104,11 @@ GLOBAL_LIST_EMPTY(loadout_boxes)
 	entry_class = LOADOUT_CAT_LAWMAN
 	spawn_thing = /obj/item/storage/box/gun/premium/desert_ranger
 
-/datum/loadout_box/wattz_2000s
-	entry_tag = "wattz 2000s"
+/datum/loadout_box/wattz_2000e
+	entry_tag = "wattz 2000e"
 	entry_flags = LOADOUT_FLAG_LAWMAN
 	entry_class = LOADOUT_CAT_LAWMAN
-	spawn_thing = /obj/item/gun/energy/laser/wattz2ks
+	spawn_thing = /obj/item/gun/energy/laser/wattz2k/extended
 
 /datum/loadout_box/rcw
 	entry_tag = "laser RCW"


### PR DESCRIPTION
## About The Pull Request
<!-- Write here -->
This PR adds the laser RCW smg, and the wattz_2000e to the Premium list
Energy weapons need some love 🥺 
## Pre-Merge Checklist
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
<!-- Tick these after making the PR. -->

## Changelog
:cl:
add: Adds Laser rcw and wattz_2000e to Premium pack options
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
