### PR TITLE
The Great Re-Uploadening

### DIFF
--- a/_maps/map_files/Blythe-small/blythe-depths.dmm
+++ b/_maps/map_files/Blythe-small/blythe-depths.dmm
@@ -96,6 +96,12 @@
 	},
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/bunker/bunkereight)
+"aL" = (
+/obj/structure/decoration/rag{
+	icon_state = "skin"
+	},
+/turf/closed/wall/r_wall/rust,
+/area/f13/bunker/bunkerthree)
 "aQ" = (
 /obj/machinery/door/locked/hard,
 /turf/open/floor/f13{
@@ -139,6 +145,13 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/neutral/neutralchess,
 /area/f13/vault/overseer)
+"ba" = (
+/obj/effect/decal/cleanable/dirt,
+/mob/living/simple_animal/hostile/handy/gutsy/flamer,
+/turf/open/floor/plating/tunnel{
+	icon_state = "tunnelrusty"
+	},
+/area/f13/bunker/bunkerthree)
 "bi" = (
 /obj/structure/closet/fridge/standard,
 /turf/open/floor/plasteel/f13/vault_floor/white,
@@ -161,7 +174,14 @@
 	},
 /area/f13/bunker/bunkerthree)
 "bn" = (
-/turf/closed/mineral/strong/wasteland,
+/obj/structure/ladder/unbreakable{
+	desc = "An extremely sturdy metal ladder, leading deep into the bunker. You feel like you should really prepare yourself before daring to venture down the ladder.";
+	height = 2;
+	id = "chewchew"
+	},
+/turf/open/floor/plating/tunnel{
+	icon_state = "tunnelchess"
+	},
 /area/f13/bunker/bunkerthree)
 "bp" = (
 /obj/machinery/computer/security/wooden_tv,
@@ -215,6 +235,12 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/yellow/yellowchess,
 /area/f13/vault/reactor)
+"bA" = (
+/obj/structure/decoration/rag{
+	icon_state = "skin"
+	},
+/turf/closed/indestructible/f13vaultrusted,
+/area/f13/bunker/bunkerthree)
 "bD" = (
 /obj/machinery/light{
 	dir = 8
@@ -297,6 +323,15 @@
 /obj/effect/landmark/start/f13/vaultdweller,
 /turf/open/floor/plasteel/f13/vault_floor/white,
 /area/f13/vault/diner)
+"bT" = (
+/obj/structure/sign/warning/radiation,
+/turf/closed/wall/rust,
+/area/f13/bunker/bunkerthree)
+"bU" = (
+/obj/effect/decal/remains/human,
+/obj/effect/spawner/lootdrop/f13/armor/tier1,
+/turf/open/floor/plasteel/cafeteria,
+/area/f13/bunker/bunkerthree)
 "bV" = (
 /obj/structure/sign/departments/medbay/alt,
 /turf/closed/wall/r_wall/f13vault{
@@ -453,6 +488,11 @@
 	icon_state = "2-i"
 	},
 /area/f13/vault/custodial)
+"cW" = (
+/obj/structure/reagent_dispensers/barrel/three,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/bunker/bunkerthree)
 "cZ" = (
 /obj/machinery/power/apc/auto_name/south,
 /obj/effect/mapping_helpers/network_builder/power_cable/auto,
@@ -531,6 +571,12 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/red/redchess,
 /area/f13/vault/security/armory)
+"dA" = (
+/obj/machinery/light/floor,
+/obj/structure/table,
+/obj/machinery/porta_turret/f13/turret_556/robot,
+/turf/open/floor/plasteel/bar,
+/area/f13/bunker/bunkerthree)
 "dB" = (
 /obj/structure/closet/locker,
 /turf/open/floor/f13,
@@ -715,8 +761,7 @@
 /area/f13/bunker/bunkertwo)
 "eS" = (
 /obj/structure/table/wood,
-/obj/effect/spawner/lootdrop/f13/armor/tier3,
-/obj/effect/spawner/lootdrop/f13/armor/tier3,
+/obj/effect/spawner/lootdrop/f13/armor/tier4,
 /turf/open/floor/f13{
 	color = "#d9c4b9";
 	icon_state = "darkrusty";
@@ -744,6 +789,12 @@
 /obj/structure/cable,
 /turf/open/floor/plasteel/f13/vault_floor/yellow/yellowchess,
 /area/f13/vault/reactor)
+"fd" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/remains/human,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ballistic/garbagetomid,
+/turf/open/floor/plasteel/cafeteria,
+/area/f13/bunker/bunkerthree)
 "fi" = (
 /obj/structure/chair/office{
 	dir = 1
@@ -794,6 +845,13 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/purple/purplechess,
 /area/f13/vault/science)
+"fO" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/oil/slippery,
+/turf/closed/indestructible/f13vaultrusted{
+	name = "rusty reinforced wall"
+	},
+/area/f13/bunker/bunkerthree)
 "fP" = (
 /mob/living/simple_animal/hostile/raider/baseball,
 /turf/open/floor/f13{
@@ -992,6 +1050,11 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/blue/bluechess,
 /area/f13/vault/medical/chemistry)
+"hp" = (
+/obj/structure/reagent_dispensers/barrel/old,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/bunker/bunkerthree)
 "hr" = (
 /obj/structure/chair/sofa/corp/left{
 	dir = 1
@@ -1047,6 +1110,14 @@
 /obj/item/gun/energy/taser,
 /turf/open/floor/plasteel/f13/vault_floor/red/redchess,
 /area/f13/vault/security)
+"hJ" = (
+/obj/structure/decoration/rag{
+	icon_state = "skin"
+	},
+/turf/closed/indestructible/f13vaultrusted{
+	name = "rusty reinforced wall"
+	},
+/area/f13/bunker/bunkerthree)
 "hO" = (
 /obj/structure/chair/left,
 /obj/machinery/light{
@@ -1054,6 +1125,16 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/vault/diner)
+"hP" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/remains/human,
+/obj/effect/spawner/lootdrop/f13/cash_random_low,
+/obj/effect/spawner/lootdrop/f13/cash_random_low,
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/open/floor/plasteel/cafeteria,
+/area/f13/bunker/bunkerthree)
 "hR" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/decal/cleanable/oil/slippery,
@@ -1189,6 +1270,11 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/red/redchess,
 /area/f13/vault/security)
+"iC" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/item/pickaxe,
+/turf/open/floor/plating/tunnel,
+/area/f13/bunker/bunkerthree)
 "iE" = (
 /obj/machinery/light/small{
 	brightness = 3;
@@ -1495,13 +1581,18 @@
 	icon_state = "darkrustysolid"
 	},
 /area/f13/ambientlighting/building/m)
+"kr" = (
+/obj/effect/decal/cleanable/dirt,
+/mob/living/simple_animal/hostile/handy/assaultron/laser,
+/turf/open/floor/plasteel/bar,
+/area/f13/bunker/bunkerthree)
 "ks" = (
 /obj/machinery/light{
 	dir = 8;
 	pixel_y = -15
 	},
 /obj/structure/table/wood,
-/obj/effect/spawner/lootdrop/f13/armor/tier3,
+/obj/effect/spawner/lootdrop/f13/armor/tier4,
 /turf/open/floor/f13{
 	color = "#d9c4b9";
 	icon_state = "darkrusty";
@@ -1599,6 +1690,10 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/f13/bunker/bunkertwo)
+"ld" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/closed/wall/rust,
+/area/f13/bunker/bunkerthree)
 "lf" = (
 /obj/effect/decal/remains/human,
 /turf/open/floor/f13,
@@ -1772,6 +1867,12 @@
 /obj/item/clothing/under/f13/vault13,
 /turf/open/floor/f13,
 /area/f13/caves)
+"mw" = (
+/obj/effect/decal/cleanable/oil/slippery,
+/turf/open/floor/plating/tunnel{
+	icon_state = "tunnelchess2"
+	},
+/area/f13/bunker/bunkerthree)
 "my" = (
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ballistic/lowmid,
 /obj/effect/decal/cleanable/dirt,
@@ -1884,6 +1985,11 @@
 /obj/structure/sign/poster/prewar/corporate_espionage,
 /turf/closed/indestructible/f13vaultrusted,
 /area/f13/bunker/bunkertwo)
+"nk" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/chair/stool/retro,
+/turf/open/floor/plasteel/bar,
+/area/f13/bunker/bunkerthree)
 "nn" = (
 /obj/structure/chair/comfy/modern,
 /obj/machinery/light{
@@ -1901,6 +2007,13 @@
 	color = "#ffe9de";
 	icon_state = "darkrusty";
 	name = "dirty floor"
+	},
+/area/f13/bunker/bunkerthree)
+"ns" = (
+/obj/effect/decal/remains/human,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating/tunnel{
+	icon_state = "tunnelchess"
 	},
 /area/f13/bunker/bunkerthree)
 "ny" = (
@@ -1942,6 +2055,14 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/blue,
 /area/f13/ambientlighting/building/m)
+"nJ" = (
+/obj/structure/decoration/rag{
+	icon_state = "skulls"
+	},
+/obj/structure/barricade/wooden/planks,
+/obj/structure/barricade/wooden/strong,
+/turf/open/floor/plating/tunnel,
+/area/f13/bunker/bunkerthree)
 "nM" = (
 /obj/machinery/door/airlock/science/glass{
 	name = "Research Storage";
@@ -1968,6 +2089,17 @@
 /obj/effect/spawner/lootdrop/f13/weapon/gun/energy/unique,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/bunker/bunkereight)
+"nQ" = (
+/obj/machinery/light{
+	dir = 4;
+	light_color = "#c1caff"
+	},
+/turf/open/floor/f13{
+	color = "#d9c4b9";
+	icon_state = "darkrusty";
+	name = "dirty floor"
+	},
+/area/f13/bunker/bunkerthree)
 "nV" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -2005,6 +2137,10 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/purple/purplechess,
 /area/f13/vault/science)
+"oj" = (
+/obj/effect/decal/remains/human,
+/turf/open/floor/plating/tunnel,
+/area/f13/bunker/bunkerthree)
 "on" = (
 /obj/effect/landmark/start/f13/vaultscientist,
 /turf/open/floor/plasteel/f13/vault_floor/purple/purplechess,
@@ -2035,6 +2171,11 @@
 "oD" = (
 /turf/closed/indestructible/vaultdoor,
 /area/hydroponics)
+"oE" = (
+/obj/effect/decal/cleanable/dirt,
+/mob/living/simple_animal/hostile/handy/assaultron,
+/turf/open/floor/plasteel/cafeteria,
+/area/f13/bunker/bunkerthree)
 "oF" = (
 /obj/structure/simple_door/metal,
 /turf/open/floor/f13{
@@ -2057,6 +2198,9 @@
 	icon_state = "darkrustysolid"
 	},
 /area/f13/ambientlighting/building/m)
+"oM" = (
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/bunker/bunkerthree)
 "oN" = (
 /obj/machinery/door/window,
 /obj/structure/cable{
@@ -2073,6 +2217,11 @@
 /obj/structure/table/glass,
 /turf/open/floor/plasteel/f13/vault_floor/white,
 /area/f13/vault/diner)
+"oS" = (
+/turf/open/floor/plating/tunnel{
+	icon_state = "tunnelchess"
+	},
+/area/f13/bunker/bunkerthree)
 "oV" = (
 /obj/machinery/light{
 	dir = 1;
@@ -2164,6 +2313,11 @@
 	},
 /turf/open/floor/f13,
 /area/f13/caves)
+"pq" = (
+/obj/effect/decal/waste,
+/mob/living/simple_animal/hostile/handy/robobrain,
+/turf/open/floor/plating/tunnel,
+/area/f13/bunker/bunkerthree)
 "pt" = (
 /obj/structure/table,
 /obj/machinery/light{
@@ -2225,6 +2379,14 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/ambientlighting/building/m)
+"pG" = (
+/obj/structure/timeddoor,
+/turf/open/floor/f13{
+	color = "#d9c4b9";
+	icon_state = "darkrusty";
+	name = "dirty floor"
+	},
+/area/f13/bunker/bunkerthree)
 "pH" = (
 /turf/closed/indestructible/vaultdoor,
 /area/f13/vault/diner)
@@ -2255,6 +2417,10 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
 /area/f13/vault/overseer)
+"pT" = (
+/obj/machinery/light/fo13colored/Red,
+/turf/closed/mineral/random/low_chance,
+/area/f13/bunker/bunkerthree)
 "pU" = (
 /obj/effect/turf_decal/vg_decals/radiation_huge,
 /obj/structure/cable{
@@ -2310,6 +2476,13 @@
 	},
 /turf/open/floor/f13,
 /area/f13/bunker/bunkertwo)
+"qj" = (
+/obj/effect/decal/remains/human,
+/obj/effect/spawner/lootdrop/f13/cash_random_high,
+/turf/open/floor/plating/tunnel{
+	icon_state = "tunnelrusty"
+	},
+/area/f13/bunker/bunkerthree)
 "qk" = (
 /obj/effect/decal/cleanable/generic,
 /obj/item/salvage/low,
@@ -2320,6 +2493,11 @@
 	icon_state = "darkrustysolid"
 	},
 /area/f13/ambientlighting/building/m)
+"qm" = (
+/turf/closed/indestructible/f13vaultrusted{
+	name = "rusty reinforced wall"
+	},
+/area/f13/bunker/bunkerthree)
 "qo" = (
 /obj/structure/junk/small/table,
 /obj/machinery/light{
@@ -2376,6 +2554,14 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/neutral/neutralchess,
 /area/f13/vault)
+"qE" = (
+/obj/effect/decal/waste{
+	icon_state = "goo8"
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/reagent_dispensers/barrel/three,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/bunker/bunkerthree)
 "qG" = (
 /obj/structure/railing{
 	dir = 1
@@ -2415,9 +2601,16 @@
 /obj/structure/closet/l3closet/scientist,
 /turf/open/floor/plasteel/f13/vault_floor/purple/purplechess,
 /area/f13/vault/science)
+"qW" = (
+/obj/effect/decal/cleanable/dirt,
+/mob/living/simple_animal/hostile/handy/robobrain,
+/obj/effect/decal/cleanable/oil/slippery,
+/turf/open/floor/plating/tunnel{
+	icon_state = "tunnelchess"
+	},
+/area/f13/bunker/bunkerthree)
 "qZ" = (
 /mob/living/simple_animal/hostile/raider/ranged/boss,
-/obj/effect/decal/cleanable/oil/slippery,
 /turf/open/floor/f13{
 	color = "#d9c4b9";
 	icon_state = "darkrusty";
@@ -2520,6 +2713,17 @@
 /obj/structure/table,
 /turf/open/floor/plasteel/f13/vault_floor/red/redchess,
 /area/f13/vault/security)
+"rQ" = (
+/obj/effect/decal/cleanable/dirt,
+/mob/living/simple_animal/hostile/handy,
+/turf/open/floor/plasteel/cafeteria,
+/area/f13/bunker/bunkerthree)
+"rT" = (
+/obj/structure/simple_door/bunker,
+/turf/open/floor/plating/tunnel{
+	icon_state = "tunnelchess"
+	},
+/area/f13/bunker/bunkerthree)
 "rU" = (
 /obj/structure/closet/locker,
 /obj/effect/spawner/lootdrop/clothing_middle,
@@ -2566,6 +2770,11 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/f13/caves)
+"sh" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/spawner/lootdrop/f13/crafting,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/bunker/bunkerthree)
 "si" = (
 /obj/structure/closet/locker/fridge,
 /obj/item/reagent_containers/food/condiment/flour,
@@ -2726,6 +2935,13 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/blue/bluechess,
 /area/f13/vault/medical/morgue)
+"ta" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/microwave/stove,
+/obj/structure/table,
+/obj/effect/decal/cleanable/oil/slippery,
+/turf/open/floor/plasteel/cafeteria,
+/area/f13/bunker/bunkerthree)
 "tc" = (
 /obj/machinery/holopad,
 /turf/open/floor/plasteel/f13/vault_floor/neutral/neutralchess,
@@ -2816,6 +3032,13 @@
 	name = "dirty floor"
 	},
 /area/f13/bunker/bunkerthree)
+"tO" = (
+/obj/structure/simple_door/bunker,
+/obj/structure/barricade/wooden/planks,
+/turf/open/floor/plating/tunnel{
+	icon_state = "tunnelchess"
+	},
+/area/f13/bunker/bunkerthree)
 "tP" = (
 /obj/machinery/vending/boozeomat{
 	force_free = 1
@@ -2866,6 +3089,11 @@
 "ui" = (
 /turf/open/floor/plasteel/f13/vault_floor/red/redchess,
 /area/f13/vault/security)
+"um" = (
+/obj/effect/decal/cleanable/dirt,
+/mob/living/simple_animal/hostile/handy/gutsy,
+/turf/open/floor/plating/tunnel,
+/area/f13/bunker/bunkerthree)
 "un" = (
 /turf/closed/indestructible/vaultdoor,
 /area/f13/vault/security/armory)
@@ -2877,6 +3105,12 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/neutral/neutralchess,
 /area/f13/vault)
+"ut" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/spawner/lootdrop/f13/attachments,
+/obj/structure/table,
+/turf/open/floor/plasteel/cafeteria,
+/area/f13/bunker/bunkerthree)
 "uv" = (
 /turf/closed/wall/r_wall/rust,
 /area/f13/caves)
@@ -2972,6 +3206,16 @@
 /obj/structure/simple_door/bunker,
 /turf/open/floor/plasteel/dark,
 /area/f13/caves)
+"vf" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/closed/indestructible/f13vaultrusted{
+	name = "rusty reinforced wall"
+	},
+/area/f13/bunker/bunkerthree)
+"vl" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating/tunnel,
+/area/f13/bunker/bunkerthree)
 "vn" = (
 /obj/machinery/door/airlock/command{
 	name = "Overseer Office";
@@ -2979,6 +3223,12 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
 /area/f13/vault/overseer)
+"vq" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating/tunnel{
+	icon_state = "tunnelrusty"
+	},
+/area/f13/bunker/bunkerthree)
 "vx" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -2993,6 +3243,12 @@
 /obj/machinery/rnd/production/circuit_imprinter,
 /turf/open/floor/plasteel/f13/vault_floor/purple/purplechess,
 /area/f13/vault/science)
+"vC" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/chem_dispenser/drinks/beer,
+/obj/structure/table,
+/turf/open/floor/plasteel/bar,
+/area/f13/bunker/bunkerthree)
 "vE" = (
 /obj/machinery/door/password,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
@@ -3011,6 +3267,19 @@
 	color = "#d9c4b9";
 	icon_state = "darkrusty";
 	name = "dirty floor"
+	},
+/area/f13/bunker/bunkerthree)
+"vK" = (
+/obj/effect/decal/remains/human,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/waste{
+	icon_state = "goo8"
+	},
+/mob/living/simple_animal/hostile/securitron/sentrybot/chew{
+	emp_flags = list()
+	},
+/turf/open/floor/plating/tunnel{
+	icon_state = "tunnelrusty"
 	},
 /area/f13/bunker/bunkerthree)
 "vL" = (
@@ -3108,6 +3377,18 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/neutral/white,
 /area/f13/vault/lavatory)
+"wk" = (
+/obj/structure/destructible/tribal_torch/wall/lit{
+	dir = 8;
+	light_color = "#f4e3b0"
+	},
+/obj/effect/decal/cleanable/oil/slippery,
+/turf/open/floor/f13{
+	color = "#d9c4b9";
+	icon_state = "darkrusty";
+	name = "dirty floor"
+	},
+/area/f13/bunker/bunkerthree)
 "wn" = (
 /turf/open/floor/plasteel/f13/vault_floor/neutral/neutralchess,
 /area/f13/underground/vault_atrium_Lower)
@@ -3132,6 +3413,12 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/f13/bunker/bunkertwo)
+"wA" = (
+/obj/structure/girder,
+/turf/open/floor/plating/tunnel{
+	icon_state = "tunnelchess"
+	},
+/area/f13/bunker/bunkerthree)
 "wB" = (
 /obj/structure/barricade/security,
 /turf/open/floor/plasteel/dark,
@@ -3307,15 +3594,7 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/ambientlighting/building/m)
 "xC" = (
-/obj/structure/destructible/tribal_torch/wall/lit{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/oil/slippery,
-/turf/open/floor/f13{
-	color = "#d9c4b9";
-	icon_state = "darkrusty";
-	name = "dirty floor"
-	},
+/turf/closed/mineral/random/low_chance,
 /area/f13/bunker/bunkerthree)
 "xD" = (
 /obj/machinery/vending/medical/free,
@@ -3361,6 +3640,23 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/blue,
 /area/f13/ambientlighting/building/m)
+"xV" = (
+/obj/effect/decal/cleanable/oil/slippery,
+/turf/open/floor/plating/tunnel{
+	icon_state = "tunnelchess"
+	},
+/area/f13/bunker/bunkerthree)
+"xY" = (
+/obj/effect/decal/remains/human,
+/obj/effect/decal/cleanable/dirt,
+/obj/item/clothing/suit/radiation,
+/obj/item/clothing/head/radiation,
+/obj/item/wrench/power,
+/obj/machinery/light/fo13colored/Red,
+/obj/effect/decal/waste,
+/obj/item/weldingtool/experimental,
+/turf/open/floor/plating/tunnel,
+/area/f13/bunker/bunkerthree)
 "xZ" = (
 /obj/structure/reagent_dispensers/fueltank,
 /turf/open/floor/plasteel/f13/vault_floor/yellow/yellowchess,
@@ -3372,6 +3668,11 @@
 	icon_state = "darkrusty";
 	name = "dirty floor"
 	},
+/area/f13/bunker/bunkerthree)
+"yd" = (
+/obj/structure/reagent_dispensers/barrel/dangerous,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/indestructible/ground/inside/mountain,
 /area/f13/bunker/bunkerthree)
 "yg" = (
 /obj/machinery/smartfridge/bottlerack/lootshelf/construction,
@@ -3438,6 +3739,13 @@
 /mob/living/simple_animal/hostile/handy/assaultron/laser,
 /turf/open/floor/plasteel/dark,
 /area/f13/ambientlighting/building/m)
+"yw" = (
+/obj/structure/girder/reinforced,
+/obj/structure/barricade/wooden/planks,
+/turf/open/floor/plating/tunnel{
+	icon_state = "tunnelchess"
+	},
+/area/f13/bunker/bunkerthree)
 "yx" = (
 /obj/structure/cable{
 	icon_state = "2-4"
@@ -3453,6 +3761,16 @@
 /obj/item/lockpick_set/bobby_pin,
 /turf/open/floor/plasteel/dark,
 /area/f13/bunker/bunkertwo)
+"yB" = (
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ballistic/superhighcargo,
+/obj/item/grenade/f13/plasma,
+/obj/item/locked_box/armor/tier3_5,
+/obj/effect/spawner/lootdrop/f13/attachments,
+/obj/item/gun/ballistic/revolver/ballisticfist,
+/turf/open/floor/plating/tunnel{
+	icon_state = "tunnelrusty"
+	},
+/area/f13/bunker/bunkerthree)
 "yE" = (
 /obj/machinery/power/port_gen/pacman/diesel,
 /obj/structure/cable{
@@ -3487,6 +3805,15 @@
 /obj/machinery/light,
 /turf/open/floor/plasteel/f13/vault_floor/purple/purplechess,
 /area/f13/vault/science)
+"yM" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/remains/human,
+/obj/structure/simple_door/bunker,
+/obj/effect/decal/cleanable/oil/slippery,
+/turf/open/floor/plating/tunnel{
+	icon_state = "tunnelchess"
+	},
+/area/f13/bunker/bunkerthree)
 "yP" = (
 /obj/structure/dresser,
 /turf/open/floor/carpet/vault,
@@ -3629,6 +3956,9 @@
 	},
 /turf/open/floor/f13,
 /area/f13/caves)
+"zE" = (
+/turf/open/floor/plating/tunnel,
+/area/f13/bunker/bunkerthree)
 "zG" = (
 /obj/machinery/light{
 	dir = 4
@@ -3734,6 +4064,12 @@
 /obj/structure/simple_door/interior,
 /turf/open/floor/plasteel/dark,
 /area/f13/caves)
+"Ag" = (
+/obj/effect/decal/remains/human,
+/turf/open/floor/plating/tunnel{
+	icon_state = "tunnelrusty"
+	},
+/area/f13/bunker/bunkerthree)
 "Ai" = (
 /obj/structure/bed/mattress{
 	icon_state = "mattress2";
@@ -3760,6 +4096,12 @@
 /obj/structure/chair/stool/f13stool,
 /turf/open/floor/plasteel/dark,
 /area/f13/caves)
+"Ax" = (
+/obj/machinery/microwave,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/table,
+/turf/open/floor/plasteel/cafeteria,
+/area/f13/bunker/bunkerthree)
 "AB" = (
 /obj/structure/barricade/wooden,
 /obj/structure/cable{
@@ -3807,7 +4149,6 @@
 /area/f13/ambientlighting/building/m)
 "AN" = (
 /obj/structure/destructible/tribal_torch/wall/lit,
-/obj/effect/decal/cleanable/oil/slippery,
 /turf/open/floor/f13{
 	color = "#d9c4b9";
 	icon_state = "darkrusty";
@@ -3906,6 +4247,12 @@
 	name = "dirty floor"
 	},
 /area/f13/bunker/bunkerthree)
+"Bs" = (
+/obj/effect/decal/cleanable/dirt,
+/mob/living/simple_animal/hostile/handy/gutsy,
+/obj/effect/decal/cleanable/oil/slippery,
+/turf/open/floor/plating/tunnel,
+/area/f13/bunker/bunkerthree)
 "Bu" = (
 /obj/structure/closet/locker,
 /obj/item/storage/belt/army/security,
@@ -3992,6 +4339,19 @@
 /obj/item/clothing/under/f13/picnicdress50s,
 /turf/open/floor/f13,
 /area/f13/caves)
+"Ca" = (
+/obj/structure/reagent_dispensers/barrel/explosive,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating/tunnel{
+	icon_state = "tunnelchess"
+	},
+/area/f13/bunker/bunkerthree)
+"Cc" = (
+/obj/structure/sign/warning/securearea{
+	desc = "A warning sign which reads 'SECURE AREA - DO NOT ENTER UNDER ANY CIRCUMSTANCE. YOU HAVE BEEN WARNED'."
+	},
+/turf/closed/wall/rust,
+/area/f13/bunker/bunkerthree)
 "Cd" = (
 /obj/machinery/light{
 	dir = 4;
@@ -4033,6 +4393,13 @@
 /obj/effect/landmark/start/f13/vaultdweller,
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/vault/diner)
+"Ct" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/girder,
+/turf/open/floor/plating/tunnel{
+	icon_state = "tunnelchess"
+	},
+/area/f13/bunker/bunkerthree)
 "Cw" = (
 /obj/machinery/vending/cigarette{
 	force_free = 1
@@ -4269,6 +4636,12 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/blue/bluechess,
 /area/f13/vault/medical/surgery)
+"DF" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/floor,
+/obj/machinery/porta_turret/f13/turret_556/robot,
+/turf/open/floor/plasteel/bar,
+/area/f13/bunker/bunkerthree)
 "DM" = (
 /obj/machinery/door/airlock{
 	name = "Restrooms"
@@ -4336,6 +4709,12 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/white,
 /area/hydroponics)
+"El" = (
+/obj/item/storage/trash_stack,
+/turf/open/floor/plating/tunnel{
+	icon_state = "tunnelrusty"
+	},
+/area/f13/bunker/bunkerthree)
 "En" = (
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/f13/armor/tier3,
@@ -4365,6 +4744,11 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/neutral/white,
 /area/f13/vault/lavatory)
+"EC" = (
+/obj/structure/reagent_dispensers/barrel/two,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/bunker/bunkerthree)
 "EE" = (
 /obj/item/radio/intercom{
 	frequency = 1361;
@@ -4375,6 +4759,11 @@
 /area/f13/vault/overseer)
 "EF" = (
 /turf/closed/indestructible/f13vaultrusted,
+/area/f13/bunker/bunkerthree)
+"EH" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/item/storage/trash_stack,
+/turf/open/floor/plasteel/bar,
 /area/f13/bunker/bunkerthree)
 "EJ" = (
 /obj/structure/table/glass,
@@ -4387,6 +4776,9 @@
 /obj/effect/spawner/lootdrop/ammo/fiftypercent,
 /turf/open/floor/plasteel/dark,
 /area/f13/caves)
+"EN" = (
+/turf/closed/wall/rust,
+/area/f13/bunker/bunkerthree)
 "EQ" = (
 /obj/machinery/processor,
 /turf/open/floor/plasteel/f13/vault_floor/white,
@@ -4472,6 +4864,14 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/red/redchess,
 /area/f13/vault/security)
+"Fr" = (
+/obj/effect/decal/waste{
+	icon_state = "goo8"
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/spawner/lootdrop/f13/cash_random_med,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/bunker/bunkerthree)
 "Fs" = (
 /obj/machinery/door/poddoor{
 	id = 103;
@@ -4498,6 +4898,13 @@
 	icon_state = "darkrusty";
 	name = "dirty floor"
 	},
+/area/f13/bunker/bunkerthree)
+"Fz" = (
+/obj/machinery/deepfryer,
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/floor/plasteel/cafeteria,
 /area/f13/bunker/bunkerthree)
 "FB" = (
 /obj/structure/chair/comfy/modern,
@@ -4553,6 +4960,12 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/vault/diner)
+"FM" = (
+/obj/effect/decal/remains/human,
+/turf/open/floor/plating/tunnel{
+	icon_state = "tunnelchess"
+	},
+/area/f13/bunker/bunkerthree)
 "FN" = (
 /obj/item/trash/tray,
 /obj/effect/decal/cleanable/dirt,
@@ -4744,6 +5157,10 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/blue/bluechess,
 /area/f13/vault/medical/chemistry)
+"Hf" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/bunker/bunkerthree)
 "Hg" = (
 /obj/machinery/vending/tool{
 	force_free = 1
@@ -4753,6 +5170,12 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/yellow/yellowchess,
 /area/f13/vault/reactor)
+"Hh" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating/tunnel{
+	icon_state = "tunnelchess"
+	},
+/area/f13/bunker/bunkerthree)
 "Hi" = (
 /obj/effect/turf_decal/stripes/box,
 /obj/effect/spawner/lootdrop/f13/blueprintHigh,
@@ -4788,6 +5211,11 @@
 /obj/effect/spawner/lootdrop/f13/crafting,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/ambientlighting/building/m)
+"Hs" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/item/storage/trash_stack,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/bunker/bunkerthree)
 "Ht" = (
 /obj/machinery/vending/wallmed,
 /turf/closed/wall/r_wall/f13vault{
@@ -5106,6 +5534,10 @@
 /obj/machinery/smartfridge/bottlerack/lootshelf/cans,
 /turf/open/floor/plasteel/dark,
 /area/f13/caves)
+"JM" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/bar,
+/area/f13/bunker/bunkerthree)
 "JO" = (
 /obj/structure/chair/right{
 	dir = 4
@@ -5157,6 +5589,11 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/purple/purplechess,
 /area/f13/vault/science)
+"Kf" = (
+/turf/open/floor/plating/tunnel{
+	icon_state = "tunnelchess2"
+	},
+/area/f13/bunker/bunkerthree)
 "Kk" = (
 /obj/structure/chair/right,
 /turf/open/floor/f13{
@@ -5245,13 +5682,29 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/green,
 /area/f13/vault/overseer)
+"KP" = (
+/obj/structure/reagent_dispensers/barrel/four,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/bunker/bunkerthree)
 "KS" = (
 /turf/closed/wall/r_wall/rust,
+/area/f13/bunker/bunkerthree)
+"KT" = (
+/obj/structure/table,
+/turf/open/floor/plasteel/cafeteria,
 /area/f13/bunker/bunkerthree)
 "KV" = (
 /obj/effect/turf_decal/stripes/box,
 /turf/open/floor/plasteel/dark,
 /area/f13/ambientlighting/building/m)
+"KY" = (
+/obj/effect/decal/remains/human,
+/obj/effect/spawner/lootdrop/f13/armor/tier2,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ballistic/garbagetomid,
+/turf/open/floor/plating/tunnel{
+	icon_state = "tunnelchess2"
+	},
+/area/f13/bunker/bunkerthree)
 "KZ" = (
 /turf/closed/wall/f13/tunnel,
 /area/f13/vault)
@@ -5396,6 +5849,14 @@
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier4,
 /turf/open/floor/plasteel/dark,
 /area/f13/caves)
+"LM" = (
+/obj/structure/reagent_dispensers/barrel/dangerous,
+/obj/effect/decal/waste,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating/tunnel{
+	icon_state = "tunnelchess"
+	},
+/area/f13/bunker/bunkerthree)
 "LQ" = (
 /obj/effect/overlay/junk/mirror{
 	pixel_y = -32
@@ -5526,6 +5987,10 @@
 /obj/machinery/chem_dispenser/drinks,
 /turf/open/floor/carpet/vault,
 /area/f13/vault/overseer)
+"MH" = (
+/obj/item/storage/trash_stack,
+/turf/open/floor/plating/tunnel,
+/area/f13/bunker/bunkerthree)
 "MI" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -5572,6 +6037,20 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/red/redchess,
 /area/f13/vault/security/armory)
+"MT" = (
+/obj/effect/decal/remains/human,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/spawner/lootdrop/f13/weapon/melee/tier5,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ballistic/lowmid,
+/obj/effect/spawner/lootdrop/f13/cash_random_low,
+/turf/open/floor/plating/tunnel,
+/area/f13/bunker/bunkerthree)
+"MU" = (
+/obj/structure/girder,
+/turf/open/floor/plating/tunnel{
+	icon_state = "tunnelrusty"
+	},
+/area/f13/bunker/bunkerthree)
 "MV" = (
 /obj/structure/fluff/railing{
 	dir = 1
@@ -5632,6 +6111,13 @@
 /obj/structure/closet/l3closet/janitor,
 /turf/open/floor/plasteel/f13/vault_floor/neutral/neutralchess,
 /area/f13/vault/custodial)
+"Nl" = (
+/obj/structure/barricade/wooden/planks,
+/obj/structure/girder,
+/turf/open/floor/plating/tunnel{
+	icon_state = "tunnelchess"
+	},
+/area/f13/bunker/bunkerthree)
 "Nq" = (
 /obj/machinery/portable_atmospherics/scrubber/huge,
 /turf/open/floor/plasteel/dark,
@@ -5750,6 +6236,10 @@
 /obj/machinery/vending/wardrobe/chem_wardrobe/free,
 /turf/open/floor/plasteel/f13/vault_floor/purple/purplechess,
 /area/f13/vault/science)
+"Oq" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/cafeteria,
+/area/f13/bunker/bunkerthree)
 "Os" = (
 /obj/machinery/light{
 	light_color = "#e8eaff"
@@ -5781,6 +6271,11 @@
 /obj/machinery/door/locked/easy/trapped,
 /turf/open/floor/plasteel/dark,
 /area/f13/caves)
+"OE" = (
+/obj/structure/reagent_dispensers/barrel/explosive,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/bunker/bunkerthree)
 "OG" = (
 /obj/structure/cable{
 	icon_state = "0-4"
@@ -5981,6 +6476,10 @@
 	name = "dirty floor"
 	},
 /area/f13/bunker/bunkerthree)
+"Qa" = (
+/obj/structure/decoration/rag,
+/turf/closed/wall/r_wall/rust,
+/area/f13/bunker/bunkerthree)
 "Qc" = (
 /obj/machinery/vending/autodrobe{
 	force_free = 1
@@ -6057,6 +6556,13 @@
 /obj/effect/turf_decal/box,
 /turf/open/floor/plasteel/dark,
 /area/f13/bunker/bunkertwo)
+"QB" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/waste{
+	icon_state = "goo8"
+	},
+/turf/open/floor/plasteel/cafeteria,
+/area/f13/bunker/bunkerthree)
 "QD" = (
 /turf/closed/mineral/random/no_caves,
 /area/f13/caves)
@@ -6131,6 +6637,13 @@
 	icon_state = "darkrustysolid"
 	},
 /area/f13/bunker/bunkereight)
+"QY" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/spawner/lootdrop/f13/cash_random_low,
+/obj/effect/spawner/lootdrop/f13/cash_random_low,
+/obj/structure/table,
+/turf/open/floor/plasteel/cafeteria,
+/area/f13/bunker/bunkerthree)
 "Rb" = (
 /obj/effect/spawner/lootdrop/f13/foodspawner,
 /turf/open/floor/plasteel/dark,
@@ -6317,6 +6830,11 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/neutral/neutralchess,
 /area/f13/vault/overseer)
+"Sv" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/item/storage/trash_stack,
+/turf/open/floor/plasteel/cafeteria,
+/area/f13/bunker/bunkerthree)
 "Sw" = (
 /obj/machinery/light{
 	dir = 1;
@@ -6327,6 +6845,9 @@
 "Sx" = (
 /turf/closed/indestructible/vaultdoor,
 /area/f13/vault/overseer)
+"Sy" = (
+/turf/open/floor/plasteel/bar,
+/area/f13/bunker/bunkerthree)
 "SB" = (
 /mob/living/simple_animal/hostile/raider/legendary,
 /obj/structure/chair/wood,
@@ -6414,6 +6935,11 @@
 	name = "dirty floor"
 	},
 /area/f13/bunker/bunkerthree)
+"Td" = (
+/obj/effect/decal/cleanable/dirt,
+/mob/living/simple_animal/hostile/radroach,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/bunker/bunkerthree)
 "Th" = (
 /obj/structure/rack/shelf_metal{
 	dir = 4
@@ -6439,6 +6965,14 @@
 "Tm" = (
 /turf/open/floor/f13,
 /area/f13/bunker/bunkertwo)
+"Tn" = (
+/obj/structure/simple_door/bunker,
+/obj/structure/barricade/wooden/planks,
+/obj/effect/decal/cleanable/oil/slippery,
+/turf/open/floor/plating/tunnel{
+	icon_state = "tunnelchess"
+	},
+/area/f13/bunker/bunkerthree)
 "Tq" = (
 /obj/structure/table,
 /obj/machinery/rnd/server/vault,
@@ -6459,6 +6993,13 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/vault/diner)
+"Tx" = (
+/obj/effect/decal/cleanable/dirt,
+/mob/living/simple_animal/hostile/securitron/sentrybot,
+/turf/open/floor/plating/tunnel{
+	icon_state = "tunnelchess2"
+	},
+/area/f13/bunker/bunkerthree)
 "Tz" = (
 /turf/closed/indestructible/riveted,
 /area/f13/tcoms)
@@ -6486,6 +7027,12 @@
 "TF" = (
 /turf/closed/indestructible/f13/obsidian,
 /area/f13/caves)
+"TH" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/chem_dispenser/drinks,
+/obj/structure/table,
+/turf/open/floor/plasteel/bar,
+/area/f13/bunker/bunkerthree)
 "TI" = (
 /obj/effect/overlay/junk/shower{
 	dir = 8
@@ -6612,6 +7159,12 @@
 	icon_state = "darkrustysolid"
 	},
 /area/f13/ambientlighting/building/m)
+"Ur" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/debris/v3,
+/obj/structure/reagent_dispensers/barrel/explosive,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/bunker/bunkerthree)
 "Us" = (
 /obj/machinery/light{
 	dir = 4;
@@ -6656,6 +7209,11 @@
 /obj/effect/landmark/start/f13/vaultsecurityofficer,
 /turf/open/floor/plasteel/f13/vault_floor/red/redchess,
 /area/f13/vault/security/armory)
+"UF" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/table,
+/turf/open/floor/plasteel/cafeteria,
+/area/f13/bunker/bunkerthree)
 "UG" = (
 /turf/closed/wall/r_wall/f13vault{
 	icon_state = "2-i"
@@ -6688,6 +7246,14 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/f13/bunker/bunkertwo)
+"UU" = (
+/obj/machinery/light/fo13colored/Red{
+	dir = 1
+	},
+/turf/open/floor/plating/tunnel{
+	icon_state = "tunnelchess2"
+	},
+/area/f13/bunker/bunkerthree)
 "UY" = (
 /obj/structure/closet/crate/bin,
 /turf/open/floor/plasteel/f13/vault_floor/neutral/neutralchess,
@@ -6810,6 +7376,10 @@
 /obj/structure/table,
 /turf/open/floor/plasteel/f13/vault_floor/blue/bluechess,
 /area/f13/vault/medical/chemistry)
+"Wf" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/closed/mineral/random/low_chance,
+/area/f13/bunker/bunkerthree)
 "Wi" = (
 /obj/structure/chair/sofa/corner{
 	dir = 4
@@ -6819,6 +7389,12 @@
 	color = "#ffe9de";
 	icon_state = "darkrusty";
 	name = "dirty floor"
+	},
+/area/f13/bunker/bunkerthree)
+"Wj" = (
+/obj/effect/decal/cleanable/blood/old,
+/turf/open/floor/plating/tunnel{
+	icon_state = "tunnelrusty"
 	},
 /area/f13/bunker/bunkerthree)
 "Wp" = (
@@ -6879,6 +7455,13 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/f13/caves)
+"WM" = (
+/obj/effect/decal/remains/human,
+/obj/effect/spawner/lootdrop/f13/armor/random,
+/turf/open/floor/plating/tunnel{
+	icon_state = "tunnelchess"
+	},
+/area/f13/bunker/bunkerthree)
 "WN" = (
 /obj/machinery/door/airlock/medical{
 	name = "Operating Theatre";
@@ -6895,6 +7478,17 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/f13/caves)
+"WR" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/oil/slippery,
+/turf/open/floor/plating/tunnel,
+/area/f13/bunker/bunkerthree)
+"WS" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/item/storage/trash_stack,
+/obj/effect/decal/cleanable/oil/slippery,
+/turf/open/floor/plasteel/cafeteria,
+/area/f13/bunker/bunkerthree)
 "WT" = (
 /obj/structure/rack/shelf_metal{
 	dir = 4
@@ -6980,6 +7574,14 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/purple/purplechess,
 /area/f13/vault/science)
+"XA" = (
+/obj/effect/decal/waste,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/oil/slippery,
+/turf/open/floor/plating/tunnel{
+	icon_state = "tunnelchess"
+	},
+/area/f13/bunker/bunkerthree)
 "XC" = (
 /obj/structure/rack/shelf_metal,
 /obj/item/stack/sheet/mineral/uranium/twentyfive,
@@ -7005,6 +7607,12 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/vault)
+"XP" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating/tunnel{
+	icon_state = "tunnelchess2"
+	},
+/area/f13/bunker/bunkerthree)
 "Yb" = (
 /obj/structure/table,
 /obj/item/reagent_containers/food/drinks/beer/light{
@@ -7047,6 +7655,10 @@
 /obj/effect/spawner/lootdrop/low_loot_toilet,
 /turf/open/floor/plasteel/dark,
 /area/f13/caves)
+"Yh" = (
+/obj/effect/decal/remains/human,
+/turf/open/floor/plasteel/cafeteria,
+/area/f13/bunker/bunkerthree)
 "Yk" = (
 /obj/structure/table,
 /obj/machinery/computer/security{
@@ -7145,6 +7757,13 @@
 /obj/effect/spawner/lootdrop/f13/alcoholspawner,
 /turf/open/floor/plasteel/dark,
 /area/f13/caves)
+"YN" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/spawner/lootdrop/f13/cash_random_low,
+/obj/structure/table,
+/obj/effect/decal/cleanable/oil/slippery,
+/turf/open/floor/plasteel/bar,
+/area/f13/bunker/bunkerthree)
 "YP" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -7206,11 +7825,27 @@
 	icon_state = "2-i"
 	},
 /area/f13/vault/security/armory)
+"Zd" = (
+/obj/machinery/light{
+	dir = 4;
+	light_color = "#c1caff"
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/oil/slippery,
+/turf/open/floor/plating/tunnel{
+	icon_state = "tunnelchess"
+	},
+/area/f13/bunker/bunkerthree)
 "Ze" = (
 /obj/structure/table,
 /obj/machinery/reagentgrinder,
 /turf/open/floor/plasteel/f13/vault_floor/purple/purplechess,
 /area/f13/vault/science)
+"Zi" = (
+/obj/effect/decal/remains/human,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating/tunnel,
+/area/f13/bunker/bunkerthree)
 "Zj" = (
 /obj/structure/chair/comfy/modern{
 	dir = 8
@@ -7304,16 +7939,18 @@
 	name = "dirty floor"
 	},
 /area/f13/bunker/bunkerthree)
+"Zz" = (
+/turf/open/floor/plating/tunnel{
+	icon_state = "tunnelrusty"
+	},
+/area/f13/bunker/bunkerthree)
 "ZA" = (
-/obj/machinery/light{
-	dir = 4;
-	light_color = "#c1caff"
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/ladder/unbreakable{
+	height = 1;
+	id = "chewchew"
 	},
-/turf/open/floor/f13{
-	color = "#d9c4b9";
-	icon_state = "darkrusty";
-	name = "dirty floor"
-	},
+/turf/open/indestructible/ground/inside/mountain,
 /area/f13/bunker/bunkerthree)
 "ZC" = (
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ballistic/mid,
@@ -7379,6 +8016,13 @@
 	icon_state = "r_wall"
 	},
 /area/f13/caves)
+"ZT" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/item/kitchen/knife/butcher,
+/obj/item/kitchen/rollingpin,
+/obj/structure/table,
+/turf/open/floor/plasteel/cafeteria,
+/area/f13/bunker/bunkerthree)
 "ZV" = (
 /obj/structure/shelf_wood,
 /obj/item/storage/toolbox/emergency,
@@ -24700,29 +25344,29 @@ TF
 TF
 TF
 TF
-TF
-TF
-TF
-TF
-TF
-TF
-TF
-TF
-TF
-TF
-TF
-TF
-TF
-TF
-TF
-TF
-TF
-TF
-TF
-TF
-TF
-TF
-TF
+xC
+xC
+xC
+xC
+xC
+xC
+xC
+xC
+qm
+xC
+xC
+xC
+xC
+xC
+xC
+xC
+xC
+xC
+xC
+qm
+xC
+xC
+EN
 TF
 TF
 TF
@@ -24902,29 +25546,29 @@ TF
 TF
 TF
 TF
-TF
-TF
-TF
-TF
-TF
-TF
-TF
-TF
-TF
-TF
-TF
-TF
-TF
-TF
-TF
-TF
-TF
-TF
-TF
-TF
-TF
-TF
-TF
+xC
+xC
+xC
+xC
+xC
+xC
+xC
+xC
+EN
+DF
+Sy
+JM
+tO
+vq
+xC
+xC
+xC
+xC
+xY
+EN
+MT
+xC
+xC
 TF
 TF
 TF
@@ -25104,29 +25748,29 @@ TF
 TF
 TF
 TF
-TF
-TF
-TF
-TF
-TF
-TF
-TF
-TF
-TF
-TF
-TF
-TF
-TF
-TF
-TF
-TF
-TF
-TF
-TF
-TF
-TF
-TF
-TF
+xC
+xC
+EN
+Td
+xC
+xC
+xC
+xC
+EN
+Sy
+Sy
+kr
+EN
+vl
+XP
+xC
+EN
+EN
+Nl
+EN
+Zi
+oj
+xC
 TF
 TF
 TF
@@ -25306,29 +25950,29 @@ TF
 TF
 TF
 TF
-TF
-TF
-TF
-TF
-TF
-TF
-TF
-TF
-TF
-TF
-TF
-TF
-TF
-TF
-TF
-TF
-TF
-TF
-TF
-TF
-TF
-TF
-TF
+xC
+Ur
+xC
+Hs
+vq
+Hf
+xC
+xC
+bT
+nk
+nk
+JM
+wA
+oj
+Tx
+xC
+EN
+oj
+Ct
+EN
+ns
+zE
+EN
 TF
 TF
 TF
@@ -25508,29 +26152,29 @@ TF
 TF
 TF
 TF
-TF
-TF
-TF
-TF
-TF
-TF
-TF
-TF
-TF
-TF
-TF
-TF
-TF
-TF
-TF
-TF
-TF
-TF
-TF
-TF
-TF
-TF
-TF
+xC
+EC
+Td
+sh
+LM
+WR
+xC
+xC
+EN
+dA
+YN
+EH
+wA
+mw
+MH
+Hh
+EN
+MH
+ba
+EN
+pq
+vl
+EN
 TF
 TF
 TF
@@ -25710,29 +26354,29 @@ TF
 TF
 TF
 TF
-TF
-TF
-TF
-TF
-TF
-TF
-TF
-TF
-TF
-TF
-TF
-TF
-TF
-TF
-TF
-TF
-TF
-TF
-TF
-TF
-TF
-TF
-TF
+xC
+xC
+Hf
+Hf
+Td
+xC
+xC
+xC
+EN
+TH
+JM
+JM
+wA
+vl
+vq
+Zz
+Tn
+Hh
+Kf
+EN
+El
+qW
+EN
 TF
 TF
 TF
@@ -25912,29 +26556,29 @@ TF
 TF
 TF
 TF
-TF
-TF
-TF
-TF
-TF
-TF
-TF
-TF
-TF
-TF
-TF
-TF
-TF
-TF
-TF
-TF
-TF
-TF
-TF
-TF
-TF
-TF
-TF
+xC
+xC
+Hs
+qE
+xC
+xC
+xC
+xC
+EN
+vC
+JM
+JM
+EN
+oS
+WM
+xC
+EN
+UU
+oS
+EN
+MU
+rT
+EN
 TF
 TF
 TF
@@ -26114,29 +26758,29 @@ TF
 TF
 TF
 TF
-TF
-TF
-TF
-TF
-TF
-TF
-TF
-TF
-TF
-TF
-TF
-TF
-TF
-TF
-TF
-TF
-TF
-TF
-TF
-TF
-TF
-TF
-TF
+xC
+xC
+Hf
+OE
+xC
+xC
+xC
+xC
+EN
+EN
+yM
+EN
+EN
+EN
+EN
+EN
+EN
+Ag
+xV
+vl
+FM
+qj
+xC
 TF
 TF
 TF
@@ -26316,29 +26960,29 @@ TF
 TF
 TF
 TF
-TF
-TF
-TF
-TF
-TF
-TF
-TF
-TF
-TF
-TF
-TF
-TF
-TF
-TF
-TF
-TF
-TF
-TF
-TF
-TF
-TF
-TF
-TF
+xC
+xC
+xC
+xC
+xC
+oM
+xC
+xC
+bT
+Fz
+Oq
+rQ
+EN
+Wf
+fd
+Yh
+EN
+XP
+oS
+vq
+Bs
+yw
+xC
 TF
 TF
 TF
@@ -26517,30 +27161,30 @@ TF
 TF
 TF
 TF
-TF
-TF
-TF
-TF
-TF
-TF
-TF
-TF
-TF
-TF
-TF
-TF
-TF
-TF
-TF
-TF
-TF
-TF
-TF
-TF
-TF
-TF
-TF
-TF
+xC
+xC
+xC
+xC
+xC
+xC
+Hf
+Ca
+pT
+Ct
+Ax
+Sv
+ut
+EN
+xC
+oE
+WS
+rT
+vq
+KY
+EN
+Cc
+tO
+EN
 TF
 TF
 TF
@@ -26719,30 +27363,30 @@ TF
 TF
 TF
 TF
-TF
-TF
-TF
-TF
-TF
-TF
-TF
-TF
-TF
-TF
-TF
-TF
-TF
-TF
-TF
-TF
-TF
-TF
-TF
-TF
-TF
-TF
-TF
-TF
+xC
+ZA
+cW
+xC
+oM
+xC
+xC
+XA
+KP
+Ct
+ta
+bU
+ZT
+Wf
+Wf
+xC
+QB
+EN
+um
+XP
+Cc
+Zz
+vK
+EN
 TF
 TF
 TF
@@ -26921,30 +27565,30 @@ TF
 TF
 TF
 TF
-TF
-TF
-TF
-TF
-TF
-TF
-TF
-TF
-TF
-TF
-TF
-TF
-TF
-TF
-TF
-TF
-TF
-TF
-TF
-TF
-TF
-TF
-TF
-TF
+xC
+Fr
+iC
+Hs
+xC
+oM
+oM
+xC
+yd
+wA
+KT
+UF
+QY
+xC
+xC
+xC
+hP
+EN
+Hh
+xC
+EN
+vq
+xC
+EN
 TF
 TF
 TF
@@ -27123,30 +27767,30 @@ TF
 TF
 TF
 TF
-TF
-TF
-TF
-TF
-TF
-TF
-TF
-TF
-TF
-TF
-TF
-TF
-TF
-TF
-TF
-TF
-TF
-TF
-TF
-TF
-TF
-TF
-TF
-TF
+xC
+xC
+vl
+hp
+xC
+xC
+xC
+xC
+yd
+EN
+EN
+EN
+Wf
+xC
+xC
+ld
+EN
+EN
+xC
+xC
+EN
+MU
+yB
+EN
 TF
 TF
 TF
@@ -27528,16 +28172,16 @@ TF
 TF
 TF
 TF
-EF
-EF
-EF
-EF
-EF
-EF
-EF
-EF
-EF
-EF
+qm
+vf
+fO
+qm
+qm
+qm
+qm
+qm
+qm
+qm
 Wv
 Wv
 Wv
@@ -27730,16 +28374,16 @@ TF
 TF
 TF
 TF
-EF
-rw
+qm
+wk
 yl
+kG
 PW
-NB
 eS
 ks
 fP
 cc
-EF
+qm
 Wv
 Wv
 Wv
@@ -27932,18 +28576,18 @@ TF
 TF
 TF
 TF
-EF
+qm
 PW
 bu
 dU
 mg
-NB
 PW
+NB
 kG
 Ne
-EF
-EF
-EF
+qm
+qm
+qm
 EF
 EF
 EF
@@ -28134,19 +28778,19 @@ TF
 TF
 TF
 TF
-EF
+qm
 PW
 QO
 qz
-PW
+NB
 jP
 qZ
 PW
 AN
-EF
-EF
+qm
+qm
 Zp
-NB
+PW
 ny
 EF
 Wv
@@ -28336,7 +28980,7 @@ TF
 TF
 TF
 TF
-EF
+qm
 jP
 hj
 tL
@@ -28348,7 +28992,7 @@ NB
 oF
 NB
 PW
-PW
+NB
 fP
 EF
 Wv
@@ -28538,19 +29182,19 @@ TF
 TF
 TF
 TF
-EF
-xC
+qm
+db
+nQ
 PW
-ZA
-PW
-bK
 NB
+bK
+PW
 Hd
 pB
-EF
-EF
+KS
+KS
 Bo
-NB
+PW
 zi
 EF
 Wv
@@ -28740,18 +29384,18 @@ TF
 TF
 TF
 TF
-EF
-EF
-EF
-EF
-EF
-EF
+qm
+aL
+aL
+nJ
+KS
+KS
 aQ
-EF
-EF
-EF
-EF
-EF
+KS
+KS
+KS
+KS
+KS
 oF
 EF
 EF
@@ -28942,19 +29586,19 @@ TF
 TF
 TF
 TF
-EF
+hJ
 bn
-bn
-bn
-bn
-EF
-PW
-EF
-EF
+Zd
+Wj
+Qa
+KS
+NB
+KS
+KS
 FS
 QI
 iE
-QE
+kG
 iE
 rw
 EF
@@ -29146,7 +29790,7 @@ TF
 TF
 EF
 EF
-EF
+bA
 EF
 EF
 EF
@@ -33605,7 +34249,7 @@ tQ
 cn
 hS
 EF
-PW
+pG
 rw
 nE
 EF
@@ -33807,7 +34451,7 @@ IU
 Vj
 FD
 oF
-PW
+pG
 PW
 nE
 EF

--- a/code/modules/mob/living/simple_animal/hostile/f13/Securitron.dm
+++ b/code/modules/mob/living/simple_animal/hostile/f13/Securitron.dm
@@ -12,7 +12,7 @@
 	icon_living = "securitron"
 	icon_dead = "securitron_dead"
 	mob_armor = ARMOR_VALUE_ROBOT_SECURITY
-	maxHealth = 100 
+	maxHealth = 100
 	health = 100
 	emp_flags = list(
 		MOB_EMP_STUN,
@@ -37,7 +37,7 @@
 
 	retreat_distance = 2
 	//how far they pull back
-	
+
 	minimum_distance = 5
 	// how close you can get before they try to pull back
 
@@ -131,7 +131,7 @@
 	icon_living = "sentrybot"
 	icon_dead = "sentrybot_dead"
 	mob_armor = ARMOR_VALUE_ROBOT_SECURITY
-	maxHealth = 150 
+	maxHealth = 150
 	health = 150
 	del_on_death = FALSE
 	melee_damage_lower = 24
@@ -193,20 +193,24 @@
 			playsound(src, 'sound/f13npc/sentry/systemfailure.ogg', 75, FALSE)
 
 // Lil chew-chew
-/mob/living/simple_animal/hostile/securitron/sentrybot/chew
+/mob/living/simple_animal/hostile/securitron/sentrybot/chew //Made it more like an old sentrybot. None of this new sentrybot shit.
 	name = "lil' chew-chew"
 	desc = "An oddly scorched pre-war military robot armed with a deadly gatling laser and covered in thick, oddly blue armor plating, the name Lil' Chew-Chew scratched onto it's front armour crudely, highlighted by small bits of white paint. There seems to be an odd pack on the monstrosity of a sentrie's back, a chute at the bottom of it - there's the most scorch-marks on the robot here, so it's safe to assume this robot is capable of explosions. Better watch out!"
 	extra_projectiles = 6
-	health = 1000
-	maxHealth = 1000 //CHONK
+	health = 800
+	maxHealth = 800 //chomk
 	obj_damage = 300
+	move_to_delay = 4.0 //bit faster
 	retreat_distance = 0
+	minimum_distance = 2 //run up to your face and magdump you bot
 	environment_smash = ENVIRONMENT_SMASH_RWALLS //wall-obliterator. perish.
 	color = "#75FFE2"
 	aggro_vision_range = 15
 	flags_1 = PREVENT_CONTENTS_EXPLOSION_1 //cannot self-harm with it's explosion spam
 	sneak_detection_threshold = EXPERT_CHECK
 	sneak_roll_modifier = DIFFICULTY_CHALLENGE
+	projectiletype = /obj/item/projectile/beam/laser/pistol/ultraweak/chewchew
+	auto_fire_delay = GUN_AUTOFIRE_DELAY_NORMAL
 
 /mob/living/simple_animal/hostile/securitron/sentrybot/chew/bullet_act(obj/item/projectile/Proj)
 	if(!Proj)

--- a/code/modules/projectiles/projectile/beams.dm
+++ b/code/modules/projectiles/projectile/beams.dm
@@ -311,6 +311,12 @@
 /obj/item/projectile/beam/laser/pistol/ultraweak
 	damage = 15 //quantity over quality
 
+//Chewchews Beam
+/obj/item/projectile/beam/laser/pistol/ultraweak/chewchew
+	damage = 13 //less dam..
+	armour_penetration = 0.25 //..more pen
+	is_reflectable = FALSE
+
 //Alrem's plasmacaster
 /obj/item/projectile/f13plasma/plasmacaster/arlem
 	name = "plasma bolt"


### PR DESCRIPTION
Chew-chew my beloved

## About The Pull Request
Brings the lil' man back to that one raider bunker in the depths z-level as an optional bossmob, including his old little cave area with ladder and everything. Figured the server could use more funny little challenges, and decided to re-add chew-chew following a chat with some people. If this gets added, i wish you all the best of luck.
![image](https://github.com/Afterglow-Ss13/afterglow-ss13/assets/76122712/2db119dc-2cc3-44a3-b9b1-f69829b7f561)
## Pre-Merge Checklist
- [Y] You tested this on a local server.
- [Y] This code did not runtime during testing.
- [Y] You documented all of your changes.
## Changelog
add: new extension to that one raider bunker
add: chew-chew laser upgrade
tweak: fixed up chew-chew to be more equivalent to the old version rather than the crappy new version- keep him a challenge.
balance: nerfed chew-chew hp and damage slightly
balance: made the boss chew-chew EMP proof
add: cool loot spawners
add: muh warnings
tweak: moved time door on Zero%'s request