### PR TITLE
Map cycle PR - Khan & Surface Trading Post Fix

### DIFF
--- a/_maps/map_files/Blythe-small/blythe-surface.dmm
+++ b/_maps/map_files/Blythe-small/blythe-surface.dmm
@@ -35365,13 +35365,6 @@
 /obj/effect/overlay/desert_side,
 /turf/open/floor/plating/f13/inside/gravel,
 /area/f13/wasteland/legion)
-"qUR" = (
-/obj/machinery/door/airlock/grunge{
-	id_tag = "floor1elevatordoors";
-	req_access_txt = "120"
-	},
-/turf/open/floor/plasteel/f13/stone,
-/area/f13/brotherhood/surface)
 "qVn" = (
 /obj/structure/sign/map/right{
 	pixel_y = 30
@@ -98737,7 +98730,7 @@ mjV
 vrW
 kAZ
 jMk
-qUR
+xHd
 eso
 eso
 eso
@@ -98939,7 +98932,7 @@ pRf
 bBH
 kAZ
 jMk
-qUR
+xHd
 wdg
 wdg
 eso

--- a/_maps/map_files/Blythe-small/blythe-surface.dmm
+++ b/_maps/map_files/Blythe-small/blythe-surface.dmm
@@ -35413,7 +35413,7 @@
 	id_tag = "floor1elevatordoors";
 	req_access_txt = "120"
 	},
-/turf/open/floor/plasteel/f13/stone,
+/turf/closed/wall/f13/store,
 /area/f13/brotherhood/surface)
 "qVn" = (
 /obj/structure/sign/map/right{

--- a/_maps/map_files/Blythe-small/blythe-surface.dmm
+++ b/_maps/map_files/Blythe-small/blythe-surface.dmm
@@ -2858,13 +2858,13 @@
 /area/f13/vault)
 "brU" = (
 /obj/structure/cable{
-	icon_state = "1-4"
-	},
-/obj/structure/cable{
-	icon_state = "1-8"
+	icon_state = "1-2"
 	},
 /turf/open/indestructible/ground/outside/desert,
-/turf/open/floor/plasteel/f13/stone,
+/turf/open/indestructible/ground/outside/sidewalk{
+	dir = 1;
+	icon_state = "horizontaloutermain1"
+	},
 /area/f13/brotherhood/surface)
 "bsy" = (
 /turf/open/indestructible/ground/outside/dirt,
@@ -3227,12 +3227,9 @@
 /area/f13/ambientlighting/building/p)
 "bBH" = (
 /obj/structure/cable{
-	icon_state = "2-4"
+	icon_state = "1-2"
 	},
-/obj/machinery/light/small{
-	dir = 8
-	},
-/turf/open/floor/plasteel/f13/stone,
+/turf/closed/wall/f13/tunnel,
 /area/f13/brotherhood/surface)
 "bBS" = (
 /obj/machinery/smartfridge/bottlerack/seedbin,
@@ -6823,6 +6820,9 @@
 /obj/structure/cable{
 	icon_state = "2-4"
 	},
+/obj/machinery/light/small{
+	dir = 8
+	},
 /turf/open/floor/plasteel/f13{
 	icon_state = "floorgrime"
 	},
@@ -9248,10 +9248,10 @@
 	},
 /area/f13/ambientlighting/building)
 "eDv" = (
-/obj/effect/decal/cleanable/dirt,
 /obj/structure/cable{
-	icon_state = "1-4"
+	icon_state = "0-4"
 	},
+/obj/machinery/power/apc/fusebox/west,
 /turf/open/floor/plasteel/f13/stone,
 /area/f13/brotherhood/surface)
 "eDF" = (
@@ -15694,6 +15694,15 @@
 /obj/effect/spawner/lootdrop/cig_packs,
 /turf/open/floor/plasteel/f13/vault_floor/misc/bar,
 /area/f13/ambientlighting/building/f)
+"hDL" = (
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/obj/machinery/light/small{
+	dir = 8
+	},
+/turf/open/floor/plasteel/f13/stone,
+/area/f13/brotherhood/surface)
 "hDS" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/indestructible/ground/outside/road{
@@ -16211,10 +16220,13 @@
 	},
 /area/f13/wasteland/city)
 "hRy" = (
-/obj/machinery/door/airlock/grunge{
-	id_tag = "floor1elevatordoors";
-	req_access_txt = "120"
+/obj/structure/cable{
+	icon_state = "1-4"
 	},
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/turf/open/indestructible/ground/outside/desert,
 /turf/open/floor/plasteel/f13/stone,
 /area/f13/brotherhood/surface)
 "hRD" = (
@@ -22832,10 +22844,10 @@
 	},
 /area/f13/building)
 "kVM" = (
-/obj/structure/cable{
-	icon_state = "0-4"
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small{
+	dir = 4
 	},
-/obj/machinery/power/apc/fusebox/west,
 /turf/open/floor/plasteel/f13/stone,
 /area/f13/brotherhood/surface)
 "kVP" = (
@@ -25454,6 +25466,17 @@
 	},
 /turf/open/floor/carpet/black,
 /area/f13/building/abandoned/a)
+"mjV" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/indestructible/ground/outside/desert,
+/turf/open/indestructible/ground/outside/sidewalk{
+	dir = 1;
+	icon_state = "horizontaloutermain1"
+	},
+/turf/open/floor/plasteel/f13/stone,
+/area/f13/brotherhood/surface)
 "mjW" = (
 /obj/effect/landmark/start/f13/ncrspecialist,
 /turf/open/floor/plasteel/f13/stone,
@@ -28059,10 +28082,13 @@
 	},
 /area/f13/ambientlighting/building/h)
 "ntm" = (
-/obj/structure/cable{
-	icon_state = "1-2"
+/obj/effect/overlay/desert/sonora/edge{
+	dir = 4
 	},
-/turf/closed/wall/r_wall/rust,
+/turf/open/indestructible/ground/outside/desert,
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "horizontaloutermain2"
+	},
 /area/f13/brotherhood/surface)
 "ntz" = (
 /obj/effect/mapping_helpers/network_builder/power_cable/red/auto,
@@ -33098,7 +33124,10 @@
 /area/f13/wasteland)
 "pRf" = (
 /obj/structure/cable{
-	icon_state = "2-8"
+	icon_state = "1-8"
+	},
+/obj/structure/cable{
+	icon_state = "1-4"
 	},
 /turf/open/indestructible/ground/outside/desert,
 /turf/open/floor/plasteel/f13/stone,
@@ -34652,6 +34681,9 @@
 /obj/structure/cable{
 	icon_state = "0-2"
 	},
+/obj/machinery/light/small{
+	dir = 8
+	},
 /turf/open/floor/plasteel/f13/stone,
 /area/f13/brotherhood/surface)
 "qCJ" = (
@@ -35387,14 +35419,13 @@
 /turf/open/floor/plating/f13/inside/gravel,
 /area/f13/wasteland/legion)
 "qUR" = (
-/obj/structure/cable{
-	icon_state = "1-8"
+/obj/effect/overlay/desert/sonora/edge{
+	dir = 8
 	},
-/obj/structure/cable{
-	icon_state = "1-4"
+/obj/effect/overlay/desert/sonora/edge,
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "horizontaloutermain2"
 	},
-/turf/open/indestructible/ground/outside/desert,
-/turf/open/floor/plasteel/f13/stone,
 /area/f13/brotherhood/surface)
 "qVn" = (
 /obj/structure/sign/map/right{
@@ -38652,6 +38683,10 @@
 "sBL" = (
 /turf/closed/wall/f13/supermart,
 /area/f13/building/mall)
+"sCc" = (
+/turf/open/indestructible/ground/outside/desert,
+/turf/open/floor/plasteel/f13/stone,
+/area/f13/brotherhood/surface)
 "sCj" = (
 /mob/living/simple_animal/hostile/ghoul/scorched/ranged,
 /obj/effect/decal/cleanable/dirt,
@@ -40144,6 +40179,7 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
+/obj/effect/overlay/desert/sonora/edge,
 /turf/open/indestructible/ground/outside/desert,
 /turf/open/indestructible/ground/outside/sidewalk{
 	dir = 1;
@@ -40152,7 +40188,7 @@
 /area/f13/brotherhood/surface)
 "tjp" = (
 /obj/effect/overlay/desert/sonora/edge{
-	dir = 4
+	dir = 8
 	},
 /turf/open/indestructible/ground/outside/desert,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -41789,7 +41825,10 @@
 /turf/open/floor/wood_common,
 /area/f13/ambientlighting/building/z)
 "uac" = (
-/turf/open/indestructible/ground/outside/desert,
+/obj/machinery/door/airlock/grunge{
+	id_tag = "floor1elevatordoors";
+	req_access_txt = "120"
+	},
 /turf/open/floor/plasteel/f13/stone,
 /area/f13/brotherhood/surface)
 "uap" = (
@@ -42064,13 +42103,9 @@
 /area/f13/ambientlighting/building/z)
 "uix" = (
 /obj/structure/cable{
-	icon_state = "1-2"
+	icon_state = "2-8"
 	},
 /turf/open/indestructible/ground/outside/desert,
-/turf/open/indestructible/ground/outside/sidewalk{
-	dir = 1;
-	icon_state = "horizontaloutermain1"
-	},
 /turf/open/floor/plasteel/f13/stone,
 /area/f13/brotherhood/surface)
 "ujc" = (
@@ -43798,11 +43833,7 @@
 	id_tag = "floor1elevatordoors";
 	req_access_txt = "120"
 	},
-/turf/open/indestructible/ground/outside/desert,
-/turf/open/indestructible/ground/outside/sidewalk{
-	dir = 1;
-	icon_state = "horizontaloutermain1"
-	},
+/turf/open/floor/plasteel/f13/stone,
 /area/f13/brotherhood/surface)
 "vaq" = (
 /obj/effect/landmark/start/f13/auxilia,
@@ -44008,10 +44039,13 @@
 /turf/open/floor/carpet/red,
 /area/f13/legioncamp)
 "vgj" = (
-/obj/structure/cable{
-	icon_state = "1-2"
+/obj/effect/overlay/desert/sonora/edge{
+	dir = 4
 	},
-/turf/closed/wall/f13/tunnel,
+/obj/effect/overlay/desert/sonora/edge,
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "horizontaloutermain2"
+	},
 /area/f13/brotherhood/surface)
 "vgD" = (
 /obj/effect/turf_decal/weather/dirt{
@@ -44760,7 +44794,7 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
+/turf/open/floor/plasteel/f13/stone,
 /area/f13/brotherhood/surface)
 "vCC" = (
 /obj/structure/fence{
@@ -47677,9 +47711,6 @@
 "wUg" = (
 /obj/machinery/power/terminal,
 /obj/structure/cable,
-/obj/machinery/light/small{
-	dir = 8
-	},
 /turf/open/floor/plasteel/f13/stone,
 /area/f13/brotherhood/surface)
 "wUG" = (
@@ -47864,13 +47895,10 @@
 	},
 /area/f13/building/hospital)
 "wYl" = (
-/obj/effect/overlay/desert/sonora/edge{
-	dir = 8
+/obj/structure/cable{
+	icon_state = "1-2"
 	},
-/turf/open/indestructible/ground/outside/desert,
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "horizontaloutermain2"
-	},
+/turf/closed/wall/r_wall/rust,
 /area/f13/brotherhood/surface)
 "wYv" = (
 /obj/effect/decal/cleanable/blood/drip,
@@ -98176,7 +98204,7 @@ fWU
 xsF
 qQe
 vCl
-eDv
+dgv
 dNF
 prL
 wEA
@@ -98567,11 +98595,11 @@ doD
 wUg
 qCH
 dgv
-kVM
-bBH
-ntm
+eDv
+hDL
+wYl
 gyY
-vgj
+bBH
 dnH
 vwc
 wdg
@@ -98769,14 +98797,14 @@ lVg
 wdg
 kNx
 qWm
-qUR
+pRf
 vrW
 kAZ
 jMk
 xHd
-uac
-uac
-uac
+sCc
+sCc
+sCc
 aFa
 xHd
 wXe
@@ -98971,14 +98999,14 @@ ydm
 wdg
 wdg
 wdg
-pRf
-brU
-wdg
+uix
 hRy
 wdg
-wdg
-wdg
 uac
+wdg
+wdg
+wdg
+sCc
 iyW
 xHd
 wXe
@@ -99379,10 +99407,10 @@ gyj
 vrW
 wdg
 jMk
+vgj
 gjF
 gjF
-gjF
-tjp
+ntm
 gjF
 gjF
 lGU
@@ -99578,15 +99606,15 @@ sPy
 sPy
 sPy
 sPy
-pRf
 uix
+mjV
 vaj
 tjo
-tjo
-tjo
-tjo
-tjo
-tjo
+brU
+brU
+brU
+brU
+brU
 ayO
 uwi
 uwi
@@ -99783,8 +99811,8 @@ sPy
 dNF
 rqt
 jMk
-dKp
-wYl
+qUR
+tjp
 dKp
 dKp
 dKp
@@ -100181,7 +100209,7 @@ jMk
 kAZ
 dNF
 yek
-dNF
+kVM
 dNF
 tzp
 dNF

--- a/_maps/map_files/Blythe-small/blythe-surface.dmm
+++ b/_maps/map_files/Blythe-small/blythe-surface.dmm
@@ -1030,6 +1030,10 @@
 /obj/structure/cable{
 	icon_state = "1-8"
 	},
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/turf/open/indestructible/ground/outside/desert,
 /turf/open/indestructible/ground/outside/sidewalk{
 	dir = 1;
 	icon_state = "horizontaloutermain1"
@@ -2856,11 +2860,10 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/structure/cable{
-	icon_state = "1-8"
-	},
+/turf/open/indestructible/ground/outside/desert,
 /turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "horizontaloutermain2"
+	dir = 1;
+	icon_state = "horizontaloutermain1"
 	},
 /area/f13/brotherhood/surface)
 "bsy" = (
@@ -3222,11 +3225,6 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/closed/wall/f13/wood/house,
 /area/f13/ambientlighting/building/p)
-"bBH" = (
-/obj/machinery/power/apc/fusebox/south,
-/obj/structure/cable,
-/turf/open/floor/plasteel/f13/stone,
-/area/f13/brotherhood/surface)
 "bBS" = (
 /obj/machinery/smartfridge/bottlerack/seedbin,
 /turf/open/floor/wood_common,
@@ -6777,11 +6775,8 @@
 	},
 /area/f13/wasteland/city)
 "dnv" = (
-/obj/structure/simple_door/interior,
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
+/turf/open/indestructible/ground/outside/desert,
+/turf/open/floor/plasteel/f13/stone,
 /area/f13/brotherhood/surface)
 "dnE" = (
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -6790,8 +6785,8 @@
 	},
 /area/f13/wasteland/city)
 "dnH" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/table,
+/obj/machinery/power/apc/fusebox/west,
+/obj/structure/cable,
 /turf/open/floor/plasteel/f13/stone,
 /area/f13/brotherhood/surface)
 "doj" = (
@@ -13357,12 +13352,6 @@
 	icon_state = "wasteland32"
 	},
 /area/f13/wasteland/city)
-"gyY" = (
-/obj/structure/cable{
-	icon_state = "1-4"
-	},
-/turf/open/indestructible/ground/outside/desert,
-/area/f13/brotherhood/surface)
 "gzv" = (
 /obj/structure/table,
 /obj/effect/decal/cleanable/dirt,
@@ -16206,8 +16195,7 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/structure/simple_door/interior,
-/turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
+/turf/closed/wall/f13/store,
 /area/f13/brotherhood/surface)
 "hRD" = (
 /obj/machinery/light{
@@ -22824,10 +22812,13 @@
 	},
 /area/f13/building)
 "kVM" = (
-/obj/machinery/light/small,
 /obj/structure/cable{
-	icon_state = "4-8"
+	icon_state = "1-8"
 	},
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/turf/open/indestructible/ground/outside/desert,
 /turf/open/floor/plasteel/f13/stone,
 /area/f13/brotherhood/surface)
 "kVP" = (
@@ -24818,7 +24809,6 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/stone,
 /area/f13/brotherhood/surface)
 "lVn" = (
@@ -25448,10 +25438,10 @@
 /turf/open/floor/carpet/black,
 /area/f13/building/abandoned/a)
 "mjV" = (
-/obj/structure/sign/poster/prewar/poster72{
-	pixel_x = -32
+/obj/structure/cable{
+	icon_state = "1-2"
 	},
-/turf/open/floor/plasteel/f13/stone,
+/turf/closed/wall/f13/tunnel,
 /area/f13/brotherhood/surface)
 "mjW" = (
 /obj/effect/landmark/start/f13/ncrspecialist,
@@ -28061,9 +28051,7 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "horizontaloutermain2"
-	},
+/turf/closed/wall/r_wall/rust,
 /area/f13/brotherhood/surface)
 "ntz" = (
 /obj/effect/mapping_helpers/network_builder/power_cable/red/auto,
@@ -28881,11 +28869,8 @@
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland)
 "nPz" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
 /obj/structure/cable{
-	icon_state = "0-2"
+	icon_state = "0-8"
 	},
 /obj/machinery/power/apc/fusebox/north,
 /turf/open/floor/plasteel/f13/stone,
@@ -33101,10 +33086,10 @@
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
 "pRf" = (
-/obj/effect/decal/cleanable/dirt,
 /obj/structure/cable{
 	icon_state = "2-8"
 	},
+/turf/open/indestructible/ground/outside/desert,
 /turf/open/floor/plasteel/f13/stone,
 /area/f13/brotherhood/surface)
 "pRi" = (
@@ -34656,7 +34641,6 @@
 /obj/structure/cable{
 	icon_state = "0-2"
 	},
-/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/stone,
 /area/f13/brotherhood/surface)
 "qCJ" = (
@@ -35393,14 +35377,13 @@
 /area/f13/wasteland/legion)
 "qUR" = (
 /obj/structure/cable{
-	icon_state = "1-4"
-	},
-/obj/structure/cable{
 	icon_state = "1-2"
 	},
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "horizontaloutermain2"
+/obj/machinery/door/airlock/grunge{
+	id_tag = "floor1elevatordoors";
+	req_access_txt = "120"
 	},
+/turf/open/floor/plasteel/f13/stone,
 /area/f13/brotherhood/surface)
 "qVn" = (
 /obj/structure/sign/map/right{
@@ -38511,7 +38494,7 @@
 /area/f13/building/mall)
 "swK" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/rack/shelf_metal,
+/obj/machinery/autolathe/ammo,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel/khanfort)
 "swM" = (
@@ -38659,9 +38642,8 @@
 /turf/closed/wall/f13/supermart,
 /area/f13/building/mall)
 "sCc" = (
-/obj/effect/decal/cleanable/dirt,
 /obj/structure/cable{
-	icon_state = "4-8"
+	icon_state = "2-4"
 	},
 /turf/open/floor/plasteel/f13/stone,
 /area/f13/brotherhood/surface)
@@ -40154,19 +40136,26 @@
 /turf/open/floor/f13/wood,
 /area/f13/building/abandoned/d)
 "tjo" = (
-/obj/effect/spawner/lootdrop/maybe_enclave_beret,
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "horizontaloutermain2"
-	},
-/area/f13/brotherhood/surface)
-"tjp" = (
 /obj/structure/cable{
 	icon_state = "1-8"
 	},
 /turf/open/indestructible/ground/outside/desert,
+/turf/open/floor/plasteel/f13/stone,
+/area/f13/brotherhood/surface)
+"tjp" = (
+/obj/effect/overlay/desert/sonora/edge{
+	dir = 8
+	},
+/turf/open/indestructible/ground/outside/desert,
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "horizontaloutermain2"
+	},
 /area/f13/brotherhood/surface)
 "tjw" = (
 /obj/structure/car/rubbish1,
@@ -41798,11 +41787,11 @@
 /turf/open/floor/wood_common,
 /area/f13/ambientlighting/building/z)
 "uac" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable{
-	icon_state = "0-2"
-	},
 /obj/machinery/power/apc/fusebox/north,
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
+/turf/open/indestructible/ground/outside/desert,
 /turf/open/floor/plasteel/f13/stone,
 /area/f13/brotherhood/surface)
 "uap" = (
@@ -42076,9 +42065,13 @@
 /turf/open/floor/wood_common,
 /area/f13/ambientlighting/building/z)
 "uix" = (
-/obj/effect/decal/cleanable/dirt,
 /obj/structure/cable{
 	icon_state = "1-2"
+	},
+/turf/open/indestructible/ground/outside/desert,
+/turf/open/indestructible/ground/outside/sidewalk{
+	dir = 1;
+	icon_state = "horizontaloutermain1"
 	},
 /turf/open/floor/plasteel/f13/stone,
 /area/f13/brotherhood/surface)
@@ -43800,17 +43793,18 @@
 	},
 /area/f13/ambientlighting/building/m)
 "vaj" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/door/airlock/hatch{
-	desc = "An airtight door, built to withstand a nuclear blast.";
-	max_integrity = 10000;
-	name = "Brotherhood of Steel";
-	req_access_txt = "120"
-	},
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/turf/open/floor/plasteel/f13/stone,
+/obj/machinery/door/airlock/grunge{
+	id_tag = "floor1elevatordoors";
+	req_access_txt = "120"
+	},
+/turf/open/indestructible/ground/outside/desert,
+/turf/open/indestructible/ground/outside/sidewalk{
+	dir = 1;
+	icon_state = "horizontaloutermain1"
+	},
 /area/f13/brotherhood/surface)
 "vaq" = (
 /obj/effect/landmark/start/f13/auxilia,
@@ -44017,15 +44011,9 @@
 /area/f13/legioncamp)
 "vgj" = (
 /obj/structure/cable{
-	icon_state = "1-2"
+	icon_state = "0-4"
 	},
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable{
-	icon_state = "1-4"
-	},
-/obj/machinery/light/small{
-	dir = 8
-	},
+/obj/machinery/power/apc/fusebox/west,
 /turf/open/floor/plasteel/f13/stone,
 /area/f13/brotherhood/surface)
 "vgD" = (
@@ -44393,6 +44381,7 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
+/turf/open/indestructible/ground/outside/desert,
 /turf/open/floor/plasteel/f13/stone,
 /area/f13/brotherhood/surface)
 "vrX" = (
@@ -47875,12 +47864,13 @@
 	},
 /area/f13/building/hospital)
 "wYl" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable{
-	icon_state = "1-8"
+/obj/effect/overlay/desert/sonora/edge{
+	dir = 4
 	},
-/turf/open/floor/plasteel/f13/stone,
+/turf/open/indestructible/ground/outside/desert,
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "horizontaloutermain2"
+	},
 /area/f13/brotherhood/surface)
 "wYv" = (
 /obj/effect/decal/cleanable/blood/drip,
@@ -98576,12 +98566,12 @@ kAZ
 doD
 wUg
 qCH
+dgv
 vgj
-eDv
-wdg
-kAZ
-jMk
-xHd
+sCc
+ntm
+hRy
+mjV
 dnH
 vwc
 wdg
@@ -98776,17 +98766,17 @@ oJv
 jMk
 kAZ
 lVg
-dNF
+wdg
 kNx
-sCc
-pRf
-bBH
+qWm
+kVM
+vrW
 kAZ
 jMk
 xHd
 uac
-eso
-dgv
+dnv
+dnv
 aFa
 xHd
 wXe
@@ -98980,15 +98970,15 @@ kAZ
 ydm
 wdg
 wdg
-qWm
-uix
-dgv
-kAZ
-jMk
-xHd
 wdg
+pRf
+tjo
+eso
+qUR
+eso
+uAf
 wdg
-sCc
+dnv
 iyW
 xHd
 wXe
@@ -99184,7 +99174,7 @@ sPy
 sPy
 sPy
 sPy
-kVM
+vrW
 kAZ
 jMk
 xHd
@@ -99387,12 +99377,12 @@ sPy
 sPy
 gyj
 vrW
-mjV
+kAZ
 jMk
 gjF
 gjF
 gjF
-lGU
+wYl
 gjF
 gjF
 lGU
@@ -99591,12 +99581,12 @@ sPy
 pRf
 uix
 vaj
-tjo
-qUR
-ntm
 brU
-ntm
-ntm
+brU
+brU
+brU
+brU
+brU
 ayO
 uwi
 uwi
@@ -99794,12 +99784,12 @@ dNF
 rqt
 jMk
 dKp
+tjp
+dKp
+dKp
+dKp
+dKp
 jvG
-dKp
-dKp
-dKp
-dKp
-dKp
 pgE
 pgE
 pgE
@@ -99996,12 +99986,12 @@ btu
 kAZ
 jMk
 fWU
+fWU
+fWU
+fWU
+fWU
+fWU
 wXe
-fWU
-fWU
-fWU
-fWU
-fWU
 anB
 anB
 anB
@@ -100198,15 +100188,15 @@ dNF
 kAZ
 jMk
 qjF
-lhH
-qQe
-gyY
+fWU
+fWU
+fWU
 knR
 fWU
-xsF
-hRy
-uix
+lhH
+eso
 dgv
+wdg
 veg
 veg
 clZ
@@ -100402,14 +100392,14 @@ jMk
 dtV
 fWU
 fud
-lhH
-qQe
-qQe
-tjp
+fWU
+fWU
+fWU
+fWU
 kAZ
 nPz
-wYl
-vSx
+wdg
+wdg
 dNF
 dNF
 dNF

--- a/_maps/map_files/Blythe-small/blythe-surface.dmm
+++ b/_maps/map_files/Blythe-small/blythe-surface.dmm
@@ -2860,7 +2860,11 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/turf/closed/wall/f13/store,
+/turf/open/indestructible/ground/outside/desert,
+/turf/open/indestructible/ground/outside/sidewalk{
+	dir = 1;
+	icon_state = "horizontaloutermain1"
+	},
 /area/f13/brotherhood/surface)
 "bsy" = (
 /turf/open/indestructible/ground/outside/dirt,
@@ -3222,10 +3226,13 @@
 /turf/closed/wall/f13/wood/house,
 /area/f13/ambientlighting/building/p)
 "bBH" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/small{
-	dir = 4
+/obj/structure/cable{
+	icon_state = "1-4"
 	},
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/turf/open/indestructible/ground/outside/desert,
 /turf/open/floor/plasteel/f13/stone,
 /area/f13/brotherhood/surface)
 "bBS" = (
@@ -13359,9 +13366,12 @@
 /area/f13/wasteland/city)
 "gyY" = (
 /obj/structure/cable{
-	icon_state = "1-2"
+	icon_state = "2-4"
 	},
-/turf/closed/wall/f13/tunnel,
+/obj/machinery/light/small{
+	dir = 8
+	},
+/turf/open/floor/plasteel/f13/stone,
 /area/f13/brotherhood/surface)
 "gzv" = (
 /obj/structure/table,
@@ -16203,14 +16213,13 @@
 	},
 /area/f13/wasteland/city)
 "hRy" = (
-/obj/structure/cable{
-	icon_state = "1-2"
+/obj/effect/overlay/desert/sonora/edge{
+	dir = 4
 	},
-/obj/machinery/door/airlock/grunge{
-	id_tag = "floor1elevatordoors";
-	req_access_txt = "120"
+/obj/effect/overlay/desert/sonora/edge,
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "horizontaloutermain2"
 	},
-/turf/open/floor/plasteel/f13/stone,
 /area/f13/brotherhood/surface)
 "hRD" = (
 /obj/machinery/light{
@@ -22827,11 +22836,13 @@
 	},
 /area/f13/building)
 "kVM" = (
-/obj/structure/cable{
-	icon_state = "4-8"
+/obj/effect/overlay/desert/sonora/edge{
+	dir = 8
 	},
-/turf/open/indestructible/ground/outside/desert,
-/turf/open/floor/plasteel/f13/stone,
+/obj/effect/overlay/desert/sonora/edge,
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "horizontaloutermain2"
+	},
 /area/f13/brotherhood/surface)
 "kVP" = (
 /obj/structure/closet/crate/bin/trashbin,
@@ -25450,13 +25461,14 @@
 /turf/open/floor/carpet/black,
 /area/f13/building/abandoned/a)
 "mjV" = (
-/obj/effect/overlay/desert/sonora/edge{
-	dir = 8
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/obj/structure/cable{
+	icon_state = "1-4"
 	},
 /turf/open/indestructible/ground/outside/desert,
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "horizontaloutermain2"
-	},
+/turf/open/floor/plasteel/f13/stone,
 /area/f13/brotherhood/surface)
 "mjW" = (
 /obj/effect/landmark/start/f13/ncrspecialist,
@@ -28063,14 +28075,13 @@
 	},
 /area/f13/ambientlighting/building/h)
 "ntm" = (
-/obj/structure/cable{
-	icon_state = "1-4"
-	},
-/obj/structure/cable{
-	icon_state = "1-8"
+/obj/effect/overlay/desert/sonora/edge{
+	dir = 4
 	},
 /turf/open/indestructible/ground/outside/desert,
-/turf/open/floor/plasteel/f13/stone,
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "horizontaloutermain2"
+	},
 /area/f13/brotherhood/surface)
 "ntz" = (
 /obj/effect/mapping_helpers/network_builder/power_cable/red/auto,
@@ -35398,14 +35409,11 @@
 /turf/open/floor/plating/f13/inside/gravel,
 /area/f13/wasteland/legion)
 "qUR" = (
-/obj/structure/cable{
-	icon_state = "1-2"
+/obj/machinery/door/airlock/grunge{
+	id_tag = "floor1elevatordoors";
+	req_access_txt = "120"
 	},
-/turf/open/indestructible/ground/outside/desert,
-/turf/open/indestructible/ground/outside/sidewalk{
-	dir = 1;
-	icon_state = "horizontaloutermain1"
-	},
+/turf/open/floor/plasteel/f13/stone,
 /area/f13/brotherhood/surface)
 "qVn" = (
 /obj/structure/sign/map/right{
@@ -38520,7 +38528,7 @@
 /area/f13/building/mall)
 "swK" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/autolathe/ammo,
+/obj/machinery/autolathe/ammo/unlocked_basic,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel/khanfort)
 "swM" = (
@@ -38668,13 +38676,10 @@
 /turf/closed/wall/f13/supermart,
 /area/f13/building/mall)
 "sCc" = (
-/obj/effect/overlay/desert/sonora/edge{
-	dir = 4
+/obj/structure/cable{
+	icon_state = "1-2"
 	},
-/obj/effect/overlay/desert/sonora/edge,
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "horizontaloutermain2"
-	},
+/turf/closed/wall/f13/store,
 /area/f13/brotherhood/surface)
 "sCj" = (
 /mob/living/simple_animal/hostile/ghoul/scorched/ranged,
@@ -40174,6 +40179,13 @@
 	dir = 1;
 	icon_state = "horizontaloutermain1"
 	},
+/area/f13/brotherhood/surface)
+"tjp" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/open/floor/plasteel/f13/stone,
 /area/f13/brotherhood/surface)
 "tjw" = (
 /obj/structure/car/rubbish1,
@@ -41806,12 +41818,9 @@
 /area/f13/ambientlighting/building/z)
 "uac" = (
 /obj/structure/cable{
-	icon_state = "2-4"
+	icon_state = "1-2"
 	},
-/obj/machinery/light/small{
-	dir = 8
-	},
-/turf/open/floor/plasteel/f13/stone,
+/turf/closed/wall/r_wall/rust,
 /area/f13/brotherhood/surface)
 "uap" = (
 /obj/structure/simple_door/interior{
@@ -43812,14 +43821,13 @@
 	},
 /area/f13/ambientlighting/building/m)
 "vaj" = (
-/obj/structure/cable{
-	icon_state = "1-8"
-	},
-/obj/structure/cable{
-	icon_state = "1-4"
+/obj/effect/overlay/desert/sonora/edge{
+	dir = 8
 	},
 /turf/open/indestructible/ground/outside/desert,
-/turf/open/floor/plasteel/f13/stone,
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "horizontaloutermain2"
+	},
 /area/f13/brotherhood/surface)
 "vaq" = (
 /obj/effect/landmark/start/f13/auxilia,
@@ -44024,13 +44032,6 @@
 	},
 /turf/open/floor/carpet/red,
 /area/f13/legioncamp)
-"vgj" = (
-/obj/machinery/door/airlock/grunge{
-	id_tag = "floor1elevatordoors";
-	req_access_txt = "120"
-	},
-/turf/open/floor/plasteel/f13/stone,
-/area/f13/brotherhood/surface)
 "vgD" = (
 /obj/effect/turf_decal/weather/dirt{
 	dir = 1
@@ -44393,13 +44394,11 @@
 	},
 /area/f13/building)
 "vrW" = (
-/obj/effect/overlay/desert/sonora/edge{
-	dir = 4
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
 /turf/open/indestructible/ground/outside/desert,
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "horizontaloutermain2"
-	},
+/turf/open/floor/plasteel/f13/stone,
 /area/f13/brotherhood/surface)
 "vrX" = (
 /obj/structure/closet/crate/footlocker{
@@ -44776,13 +44775,14 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/building)
 "vCl" = (
-/obj/effect/overlay/desert/sonora/edge{
-	dir = 8
+/obj/structure/cable{
+	icon_state = "1-2"
 	},
-/obj/effect/overlay/desert/sonora/edge,
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "horizontaloutermain2"
+/obj/machinery/door/airlock/grunge{
+	id_tag = "floor1elevatordoors";
+	req_access_txt = "120"
 	},
+/turf/open/floor/plasteel/f13/stone,
 /area/f13/brotherhood/surface)
 "vCC" = (
 /obj/structure/fence{
@@ -47886,7 +47886,7 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/turf/closed/wall/r_wall/rust,
+/turf/closed/wall/f13/tunnel,
 /area/f13/brotherhood/surface)
 "wYv" = (
 /obj/effect/decal/cleanable/blood/drip,
@@ -98191,7 +98191,7 @@ fWU
 fWU
 xsF
 qQe
-hRy
+vCl
 dgv
 dNF
 prL
@@ -98584,10 +98584,10 @@ wUg
 qCH
 dgv
 eDv
-uac
-wYl
-brU
 gyY
+uac
+sCc
+wYl
 dnH
 vwc
 wdg
@@ -98785,8 +98785,8 @@ lVg
 wdg
 kNx
 qWm
-vaj
-kVM
+mjV
+vrW
 kAZ
 jMk
 xHd
@@ -98988,9 +98988,9 @@ wdg
 wdg
 wdg
 pRf
-ntm
+bBH
 wdg
-vgj
+qUR
 wdg
 wdg
 wdg
@@ -99190,7 +99190,7 @@ sPy
 sPy
 sPy
 sPy
-kVM
+vrW
 wdg
 jMk
 xHd
@@ -99392,13 +99392,13 @@ sPy
 sPy
 sPy
 gyj
-kVM
+vrW
 wdg
 jMk
-sCc
+hRy
 gjF
 gjF
-vrW
+ntm
 gjF
 gjF
 lGU
@@ -99596,13 +99596,13 @@ sPy
 sPy
 pRf
 uix
-hRy
+vCl
 tjo
-qUR
-qUR
-qUR
-qUR
-qUR
+brU
+brU
+brU
+brU
+brU
 ayO
 uwi
 uwi
@@ -99799,8 +99799,8 @@ sPy
 dNF
 rqt
 jMk
-vCl
-mjV
+kVM
+vaj
 dKp
 dKp
 dKp
@@ -100197,7 +100197,7 @@ jMk
 kAZ
 dNF
 yek
-bBH
+tjp
 dNF
 tzp
 dNF
@@ -100210,7 +100210,7 @@ fWU
 knR
 fWU
 lhH
-hRy
+vCl
 dgv
 wdg
 veg

--- a/_maps/map_files/Blythe-small/blythe-surface.dmm
+++ b/_maps/map_files/Blythe-small/blythe-surface.dmm
@@ -1033,7 +1033,6 @@
 /obj/structure/cable{
 	icon_state = "1-4"
 	},
-/turf/open/indestructible/ground/outside/desert,
 /turf/open/indestructible/ground/outside/sidewalk{
 	dir = 1;
 	icon_state = "horizontaloutermain1"
@@ -2860,7 +2859,6 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/turf/open/indestructible/ground/outside/desert,
 /turf/open/indestructible/ground/outside/sidewalk{
 	dir = 1;
 	icon_state = "horizontaloutermain1"
@@ -7593,14 +7591,6 @@
 	icon_state = "verticaloutermain1"
 	},
 /area/f13/wasteland)
-"dKp" = (
-/obj/effect/overlay/desert/sonora/edge{
-	dir = 8
-	},
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "horizontaloutermain2"
-	},
-/area/f13/brotherhood/surface)
 "dKM" = (
 /obj/structure/flora/tree/tall{
 	layer = 2;
@@ -12421,11 +12411,6 @@
 	},
 /turf/open/floor/wood_common,
 /area/f13/ambientlighting/building/j)
-"gcJ" = (
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "horizontaloutermain2"
-	},
-/area/f13/brotherhood/surface)
 "gcM" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/chair/sofa/right{
@@ -12688,14 +12673,6 @@
 /obj/structure/decoration/rag,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/building/tribal)
-"gjF" = (
-/obj/effect/overlay/desert/sonora/edge{
-	dir = 4
-	},
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "horizontaloutermain2"
-	},
-/area/f13/brotherhood/surface)
 "gjL" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -16218,7 +16195,8 @@
 	},
 /obj/effect/overlay/desert/sonora/edge,
 /turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "horizontaloutermain2"
+	dir = 1;
+	icon_state = "horizontaloutermain1"
 	},
 /area/f13/brotherhood/surface)
 "hRD" = (
@@ -19633,7 +19611,8 @@
 	icon_state = "4-8"
 	},
 /turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "horizontaloutermain2"
+	dir = 1;
+	icon_state = "horizontaloutermain1"
 	},
 /area/f13/brotherhood/surface)
 "jvQ" = (
@@ -22841,7 +22820,8 @@
 	},
 /obj/effect/overlay/desert/sonora/edge,
 /turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "horizontaloutermain2"
+	dir = 1;
+	icon_state = "horizontaloutermain1"
 	},
 /area/f13/brotherhood/surface)
 "kVP" = (
@@ -24204,7 +24184,8 @@
 	icon_state = "4-8"
 	},
 /turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "horizontaloutermain2"
+	dir = 1;
+	icon_state = "horizontaloutermain1"
 	},
 /area/f13/brotherhood/surface)
 "lHa" = (
@@ -24428,14 +24409,6 @@
 	},
 /turf/open/floor/f13,
 /area/f13/building)
-"lMy" = (
-/obj/effect/overlay/desert/sonora/edge{
-	dir = 8
-	},
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "verticaloutermain3"
-	},
-/area/f13/brotherhood/surface)
 "lMA" = (
 /obj/effect/overlay/desert/sonora/edge/corner{
 	dir = 8
@@ -25087,7 +25060,8 @@
 	dir = 8
 	},
 /turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "horizontaloutermain2"
+	dir = 1;
+	icon_state = "horizontaloutermain1"
 	},
 /area/f13/brotherhood/surface)
 "mbL" = (
@@ -26445,14 +26419,6 @@
 /obj/machinery/jukebox,
 /turf/open/floor/wood_common,
 /area/f13/bar)
-"mHc" = (
-/obj/effect/overlay/desert/sonora/edge{
-	dir = 4
-	},
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "horizontaloutermain0"
-	},
-/area/f13/brotherhood/surface)
 "mHp" = (
 /obj/structure/reagent_dispensers/barrel/explosive,
 /obj/structure/reagent_dispensers/barrel/explosive{
@@ -28074,15 +28040,6 @@
 	icon_state = "floorrusty"
 	},
 /area/f13/ambientlighting/building/h)
-"ntm" = (
-/obj/effect/overlay/desert/sonora/edge{
-	dir = 4
-	},
-/turf/open/indestructible/ground/outside/desert,
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "horizontaloutermain2"
-	},
-/area/f13/brotherhood/surface)
 "ntz" = (
 /obj/effect/mapping_helpers/network_builder/power_cable/red/auto,
 /turf/closed/wall/f13/wood/house,
@@ -35413,7 +35370,7 @@
 	id_tag = "floor1elevatordoors";
 	req_access_txt = "120"
 	},
-/turf/closed/wall/f13/store,
+/turf/open/floor/plasteel/f13/stone,
 /area/f13/brotherhood/surface)
 "qVn" = (
 /obj/structure/sign/map/right{
@@ -40174,7 +40131,6 @@
 	icon_state = "1-2"
 	},
 /obj/effect/overlay/desert/sonora/edge,
-/turf/open/indestructible/ground/outside/desert,
 /turf/open/indestructible/ground/outside/sidewalk{
 	dir = 1;
 	icon_state = "horizontaloutermain1"
@@ -43820,15 +43776,6 @@
 	icon_state = "bluedirtychess2"
 	},
 /area/f13/ambientlighting/building/m)
-"vaj" = (
-/obj/effect/overlay/desert/sonora/edge{
-	dir = 8
-	},
-/turf/open/indestructible/ground/outside/desert,
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "horizontaloutermain2"
-	},
-/area/f13/brotherhood/surface)
 "vaq" = (
 /obj/effect/landmark/start/f13/auxilia,
 /turf/open/floor/wood_common,
@@ -45761,7 +45708,8 @@
 	dir = 4
 	},
 /turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "horizontaloutermain2"
+	dir = 1;
+	icon_state = "horizontaloutermain1"
 	},
 /area/f13/brotherhood/surface)
 "wbl" = (
@@ -98789,7 +98737,7 @@ mjV
 vrW
 kAZ
 jMk
-xHd
+qUR
 eso
 eso
 eso
@@ -98989,9 +98937,9 @@ wdg
 wdg
 pRf
 bBH
-wdg
+kAZ
+jMk
 qUR
-wdg
 wdg
 wdg
 eso
@@ -99191,7 +99139,7 @@ sPy
 sPy
 sPy
 vrW
-wdg
+kAZ
 jMk
 xHd
 xHd
@@ -99396,17 +99344,17 @@ vrW
 wdg
 jMk
 hRy
-gjF
-gjF
-ntm
-gjF
-gjF
-lGU
-gjF
-wbd
-gjF
 oTY
-mHc
+oTY
+oTY
+oTY
+oTY
+lGU
+oTY
+wbd
+oTY
+oTY
+oTY
 oTY
 fMS
 ylL
@@ -99606,11 +99554,11 @@ brU
 ayO
 uwi
 uwi
-gcJ
 uwi
-gcJ
-gcJ
-gcJ
+uwi
+uwi
+uwi
+uwi
 bEH
 bEH
 fcX
@@ -99800,18 +99748,18 @@ dNF
 rqt
 jMk
 kVM
-vaj
-dKp
-dKp
-dKp
-dKp
+pgE
+pgE
+pgE
+pgE
+pgE
 jvG
 pgE
 pgE
 pgE
 pgE
 pgE
-lMy
+pgE
 mbJ
 bmn
 aGV

--- a/_maps/map_files/Blythe-small/blythe-surface.dmm
+++ b/_maps/map_files/Blythe-small/blythe-surface.dmm
@@ -2857,13 +2857,10 @@
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/vault)
 "brU" = (
-/obj/effect/overlay/desert/sonora/edge{
-	dir = 4
+/obj/structure/cable{
+	icon_state = "1-2"
 	},
-/turf/open/indestructible/ground/outside/desert,
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "horizontaloutermain2"
-	},
+/turf/closed/wall/f13/store,
 /area/f13/brotherhood/surface)
 "bsy" = (
 /turf/open/indestructible/ground/outside/dirt,
@@ -3225,10 +3222,10 @@
 /turf/closed/wall/f13/wood/house,
 /area/f13/ambientlighting/building/p)
 "bBH" = (
-/obj/structure/cable{
-	icon_state = "4-8"
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small{
+	dir = 4
 	},
-/turf/open/indestructible/ground/outside/desert,
 /turf/open/floor/plasteel/f13/stone,
 /area/f13/brotherhood/surface)
 "bBS" = (
@@ -4236,11 +4233,8 @@
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland/legion)
 "cbY" = (
-/obj/structure/fence{
-	dir = 8
-	},
 /obj/effect/overlay/desert_side,
-/turf/open/indestructible/ground/outside/gravel,
+/turf/closed/wall/r_wall/rust,
 /area/f13/wasteland/town)
 "cbZ" = (
 /obj/effect/turf_decal/trimline/yellow/line{
@@ -8843,10 +8837,8 @@
 	},
 /area/f13/wasteland)
 "eso" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/closed/wall/r_wall/rust,
+/turf/open/indestructible/ground/outside/desert,
+/turf/open/floor/plasteel/f13/stone,
 /area/f13/brotherhood/surface)
 "esF" = (
 /obj/structure/closet/crate/bin,
@@ -13365,6 +13357,12 @@
 	icon_state = "wasteland32"
 	},
 /area/f13/wasteland/city)
+"gyY" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/closed/wall/f13/tunnel,
+/area/f13/brotherhood/surface)
 "gzv" = (
 /obj/structure/table,
 /obj/effect/decal/cleanable/dirt,
@@ -16208,7 +16206,11 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/turf/closed/wall/f13/store,
+/obj/machinery/door/airlock/grunge{
+	id_tag = "floor1elevatordoors";
+	req_access_txt = "120"
+	},
+/turf/open/floor/plasteel/f13/stone,
 /area/f13/brotherhood/surface)
 "hRD" = (
 /obj/machinery/light{
@@ -22826,10 +22828,7 @@
 /area/f13/building)
 "kVM" = (
 /obj/structure/cable{
-	icon_state = "1-4"
-	},
-/obj/structure/cable{
-	icon_state = "1-8"
+	icon_state = "4-8"
 	},
 /turf/open/indestructible/ground/outside/desert,
 /turf/open/floor/plasteel/f13/stone,
@@ -28065,13 +28064,13 @@
 /area/f13/ambientlighting/building/h)
 "ntm" = (
 /obj/structure/cable{
-	icon_state = "1-2"
+	icon_state = "1-4"
+	},
+/obj/structure/cable{
+	icon_state = "1-8"
 	},
 /turf/open/indestructible/ground/outside/desert,
-/turf/open/indestructible/ground/outside/sidewalk{
-	dir = 1;
-	icon_state = "horizontaloutermain1"
-	},
+/turf/open/floor/plasteel/f13/stone,
 /area/f13/brotherhood/surface)
 "ntz" = (
 /obj/effect/mapping_helpers/network_builder/power_cable/red/auto,
@@ -33107,10 +33106,7 @@
 /area/f13/wasteland)
 "pRf" = (
 /obj/structure/cable{
-	icon_state = "1-8"
-	},
-/obj/structure/cable{
-	icon_state = "1-4"
+	icon_state = "2-8"
 	},
 /turf/open/indestructible/ground/outside/desert,
 /turf/open/floor/plasteel/f13/stone,
@@ -35410,7 +35406,6 @@
 	dir = 1;
 	icon_state = "horizontaloutermain1"
 	},
-/turf/open/floor/plasteel/f13/stone,
 /area/f13/brotherhood/surface)
 "qVn" = (
 /obj/structure/sign/map/right{
@@ -35983,7 +35978,11 @@
 	},
 /area/f13/wasteland/city)
 "rje" = (
-/obj/machinery/workbench/fbench,
+/obj/machinery/autolathe/ammo,
+/obj/item/book/granter/crafting_recipe/gunsmith_four,
+/obj/item/book/granter/crafting_recipe/gunsmith_one,
+/obj/item/book/granter/crafting_recipe/gunsmith_three,
+/obj/item/book/granter/crafting_recipe/gunsmith_two,
 /turf/open/indestructible/ground/outside/gravel,
 /area/f13/wasteland/town)
 "rjA" = (
@@ -38669,13 +38668,13 @@
 /turf/closed/wall/f13/supermart,
 /area/f13/building/mall)
 "sCc" = (
-/obj/structure/cable{
-	icon_state = "2-4"
+/obj/effect/overlay/desert/sonora/edge{
+	dir = 4
 	},
-/obj/machinery/light/small{
-	dir = 8
+/obj/effect/overlay/desert/sonora/edge,
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "horizontaloutermain2"
 	},
-/turf/open/floor/plasteel/f13/stone,
 /area/f13/brotherhood/surface)
 "sCj" = (
 /mob/living/simple_animal/hostile/ghoul/scorched/ranged,
@@ -40175,13 +40174,6 @@
 	dir = 1;
 	icon_state = "horizontaloutermain1"
 	},
-/area/f13/brotherhood/surface)
-"tjp" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/small{
-	dir = 4
-	},
-/turf/open/floor/plasteel/f13/stone,
 /area/f13/brotherhood/surface)
 "tjw" = (
 /obj/structure/car/rubbish1,
@@ -41813,7 +41805,12 @@
 /turf/open/floor/wood_common,
 /area/f13/ambientlighting/building/z)
 "uac" = (
-/turf/open/indestructible/ground/outside/desert,
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/obj/machinery/light/small{
+	dir = 8
+	},
 /turf/open/floor/plasteel/f13/stone,
 /area/f13/brotherhood/surface)
 "uap" = (
@@ -42088,9 +42085,13 @@
 /area/f13/ambientlighting/building/z)
 "uix" = (
 /obj/structure/cable{
-	icon_state = "2-8"
+	icon_state = "1-2"
 	},
 /turf/open/indestructible/ground/outside/desert,
+/turf/open/indestructible/ground/outside/sidewalk{
+	dir = 1;
+	icon_state = "horizontaloutermain1"
+	},
 /turf/open/floor/plasteel/f13/stone,
 /area/f13/brotherhood/surface)
 "ujc" = (
@@ -43812,12 +43813,12 @@
 /area/f13/ambientlighting/building/m)
 "vaj" = (
 /obj/structure/cable{
-	icon_state = "1-2"
+	icon_state = "1-8"
 	},
-/obj/machinery/door/airlock/grunge{
-	id_tag = "floor1elevatordoors";
-	req_access_txt = "120"
+/obj/structure/cable{
+	icon_state = "1-4"
 	},
+/turf/open/indestructible/ground/outside/desert,
 /turf/open/floor/plasteel/f13/stone,
 /area/f13/brotherhood/surface)
 "vaq" = (
@@ -44024,13 +44025,11 @@
 /turf/open/floor/carpet/red,
 /area/f13/legioncamp)
 "vgj" = (
-/obj/effect/overlay/desert/sonora/edge{
-	dir = 8
+/obj/machinery/door/airlock/grunge{
+	id_tag = "floor1elevatordoors";
+	req_access_txt = "120"
 	},
-/obj/effect/overlay/desert/sonora/edge,
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "horizontaloutermain2"
-	},
+/turf/open/floor/plasteel/f13/stone,
 /area/f13/brotherhood/surface)
 "vgD" = (
 /obj/effect/turf_decal/weather/dirt{
@@ -44394,11 +44393,13 @@
 	},
 /area/f13/building)
 "vrW" = (
-/obj/machinery/door/airlock/grunge{
-	id_tag = "floor1elevatordoors";
-	req_access_txt = "120"
+/obj/effect/overlay/desert/sonora/edge{
+	dir = 4
 	},
-/turf/open/floor/plasteel/f13/stone,
+/turf/open/indestructible/ground/outside/desert,
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "horizontaloutermain2"
+	},
 /area/f13/brotherhood/surface)
 "vrX" = (
 /obj/structure/closet/crate/footlocker{
@@ -44776,7 +44777,7 @@
 /area/f13/building)
 "vCl" = (
 /obj/effect/overlay/desert/sonora/edge{
-	dir = 4
+	dir = 8
 	},
 /obj/effect/overlay/desert/sonora/edge,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -47885,7 +47886,7 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/turf/closed/wall/f13/tunnel,
+/turf/closed/wall/r_wall/rust,
 /area/f13/brotherhood/surface)
 "wYv" = (
 /obj/effect/decal/cleanable/blood/drip,
@@ -98190,7 +98191,7 @@ fWU
 fWU
 xsF
 qQe
-vaj
+hRy
 dgv
 dNF
 prL
@@ -98583,10 +98584,10 @@ wUg
 qCH
 dgv
 eDv
-sCc
-eso
-hRy
+uac
 wYl
+brU
+gyY
 dnH
 vwc
 wdg
@@ -98784,14 +98785,14 @@ lVg
 wdg
 kNx
 qWm
-pRf
-bBH
+vaj
+kVM
 kAZ
 jMk
 xHd
-uac
-uac
-uac
+eso
+eso
+eso
 aFa
 xHd
 wXe
@@ -98986,14 +98987,14 @@ ydm
 wdg
 wdg
 wdg
-uix
-kVM
+pRf
+ntm
 wdg
-vrW
+vgj
 wdg
 wdg
 wdg
-uac
+eso
 iyW
 xHd
 wXe
@@ -99189,7 +99190,7 @@ sPy
 sPy
 sPy
 sPy
-bBH
+kVM
 wdg
 jMk
 xHd
@@ -99391,13 +99392,13 @@ sPy
 sPy
 sPy
 gyj
-bBH
+kVM
 wdg
 jMk
-vCl
+sCc
 gjF
 gjF
-brU
+vrW
 gjF
 gjF
 lGU
@@ -99593,15 +99594,15 @@ sPy
 sPy
 sPy
 sPy
+pRf
 uix
-qUR
-vaj
+hRy
 tjo
-ntm
-ntm
-ntm
-ntm
-ntm
+qUR
+qUR
+qUR
+qUR
+qUR
 ayO
 uwi
 uwi
@@ -99798,7 +99799,7 @@ sPy
 dNF
 rqt
 jMk
-vgj
+vCl
 mjV
 dKp
 dKp
@@ -100196,7 +100197,7 @@ jMk
 kAZ
 dNF
 yek
-tjp
+bBH
 dNF
 tzp
 dNF
@@ -100209,7 +100210,7 @@ fWU
 knR
 fWU
 lhH
-vaj
+hRy
 dgv
 wdg
 veg

--- a/_maps/map_files/Blythe-small/blythe-surface.dmm
+++ b/_maps/map_files/Blythe-small/blythe-surface.dmm
@@ -2857,13 +2857,12 @@
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/vault)
 "brU" = (
-/obj/structure/cable{
-	icon_state = "1-2"
+/obj/effect/overlay/desert/sonora/edge{
+	dir = 4
 	},
 /turf/open/indestructible/ground/outside/desert,
 /turf/open/indestructible/ground/outside/sidewalk{
-	dir = 1;
-	icon_state = "horizontaloutermain1"
+	icon_state = "horizontaloutermain2"
 	},
 /area/f13/brotherhood/surface)
 "bsy" = (
@@ -3227,9 +3226,10 @@
 /area/f13/ambientlighting/building/p)
 "bBH" = (
 /obj/structure/cable{
-	icon_state = "1-2"
+	icon_state = "4-8"
 	},
-/turf/closed/wall/f13/tunnel,
+/turf/open/indestructible/ground/outside/desert,
+/turf/open/floor/plasteel/f13/stone,
 /area/f13/brotherhood/surface)
 "bBS" = (
 /obj/machinery/smartfridge/bottlerack/seedbin,
@@ -8846,7 +8846,7 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/turf/open/floor/plasteel/f13/stone,
+/turf/closed/wall/r_wall/rust,
 /area/f13/brotherhood/surface)
 "esF" = (
 /obj/structure/closet/crate/bin,
@@ -13365,12 +13365,6 @@
 	icon_state = "wasteland32"
 	},
 /area/f13/wasteland/city)
-"gyY" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/closed/wall/f13/store,
-/area/f13/brotherhood/surface)
 "gzv" = (
 /obj/structure/table,
 /obj/effect/decal/cleanable/dirt,
@@ -15694,15 +15688,6 @@
 /obj/effect/spawner/lootdrop/cig_packs,
 /turf/open/floor/plasteel/f13/vault_floor/misc/bar,
 /area/f13/ambientlighting/building/f)
-"hDL" = (
-/obj/structure/cable{
-	icon_state = "2-4"
-	},
-/obj/machinery/light/small{
-	dir = 8
-	},
-/turf/open/floor/plasteel/f13/stone,
-/area/f13/brotherhood/surface)
 "hDS" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/indestructible/ground/outside/road{
@@ -16221,13 +16206,9 @@
 /area/f13/wasteland/city)
 "hRy" = (
 /obj/structure/cable{
-	icon_state = "1-4"
+	icon_state = "1-2"
 	},
-/obj/structure/cable{
-	icon_state = "1-8"
-	},
-/turf/open/indestructible/ground/outside/desert,
-/turf/open/floor/plasteel/f13/stone,
+/turf/closed/wall/f13/store,
 /area/f13/brotherhood/surface)
 "hRD" = (
 /obj/machinery/light{
@@ -22844,10 +22825,13 @@
 	},
 /area/f13/building)
 "kVM" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/small{
-	dir = 4
+/obj/structure/cable{
+	icon_state = "1-4"
 	},
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/turf/open/indestructible/ground/outside/desert,
 /turf/open/floor/plasteel/f13/stone,
 /area/f13/brotherhood/surface)
 "kVP" = (
@@ -25467,15 +25451,13 @@
 /turf/open/floor/carpet/black,
 /area/f13/building/abandoned/a)
 "mjV" = (
-/obj/structure/cable{
-	icon_state = "1-2"
+/obj/effect/overlay/desert/sonora/edge{
+	dir = 8
 	},
 /turf/open/indestructible/ground/outside/desert,
 /turf/open/indestructible/ground/outside/sidewalk{
-	dir = 1;
-	icon_state = "horizontaloutermain1"
+	icon_state = "horizontaloutermain2"
 	},
-/turf/open/floor/plasteel/f13/stone,
 /area/f13/brotherhood/surface)
 "mjW" = (
 /obj/effect/landmark/start/f13/ncrspecialist,
@@ -28082,12 +28064,13 @@
 	},
 /area/f13/ambientlighting/building/h)
 "ntm" = (
-/obj/effect/overlay/desert/sonora/edge{
-	dir = 4
+/obj/structure/cable{
+	icon_state = "1-2"
 	},
 /turf/open/indestructible/ground/outside/desert,
 /turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "horizontaloutermain2"
+	dir = 1;
+	icon_state = "horizontaloutermain1"
 	},
 /area/f13/brotherhood/surface)
 "ntz" = (
@@ -35419,13 +35402,15 @@
 /turf/open/floor/plating/f13/inside/gravel,
 /area/f13/wasteland/legion)
 "qUR" = (
-/obj/effect/overlay/desert/sonora/edge{
-	dir = 8
+/obj/structure/cable{
+	icon_state = "1-2"
 	},
-/obj/effect/overlay/desert/sonora/edge,
+/turf/open/indestructible/ground/outside/desert,
 /turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "horizontaloutermain2"
+	dir = 1;
+	icon_state = "horizontaloutermain1"
 	},
+/turf/open/floor/plasteel/f13/stone,
 /area/f13/brotherhood/surface)
 "qVn" = (
 /obj/structure/sign/map/right{
@@ -38684,7 +38669,12 @@
 /turf/closed/wall/f13/supermart,
 /area/f13/building/mall)
 "sCc" = (
-/turf/open/indestructible/ground/outside/desert,
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/obj/machinery/light/small{
+	dir = 8
+	},
 /turf/open/floor/plasteel/f13/stone,
 /area/f13/brotherhood/surface)
 "sCj" = (
@@ -40187,13 +40177,11 @@
 	},
 /area/f13/brotherhood/surface)
 "tjp" = (
-/obj/effect/overlay/desert/sonora/edge{
-	dir = 8
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small{
+	dir = 4
 	},
-/turf/open/indestructible/ground/outside/desert,
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "horizontaloutermain2"
-	},
+/turf/open/floor/plasteel/f13/stone,
 /area/f13/brotherhood/surface)
 "tjw" = (
 /obj/structure/car/rubbish1,
@@ -41825,10 +41813,7 @@
 /turf/open/floor/wood_common,
 /area/f13/ambientlighting/building/z)
 "uac" = (
-/obj/machinery/door/airlock/grunge{
-	id_tag = "floor1elevatordoors";
-	req_access_txt = "120"
-	},
+/turf/open/indestructible/ground/outside/desert,
 /turf/open/floor/plasteel/f13/stone,
 /area/f13/brotherhood/surface)
 "uap" = (
@@ -44040,7 +44025,7 @@
 /area/f13/legioncamp)
 "vgj" = (
 /obj/effect/overlay/desert/sonora/edge{
-	dir = 4
+	dir = 8
 	},
 /obj/effect/overlay/desert/sonora/edge,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -44409,10 +44394,10 @@
 	},
 /area/f13/building)
 "vrW" = (
-/obj/structure/cable{
-	icon_state = "4-8"
+/obj/machinery/door/airlock/grunge{
+	id_tag = "floor1elevatordoors";
+	req_access_txt = "120"
 	},
-/turf/open/indestructible/ground/outside/desert,
 /turf/open/floor/plasteel/f13/stone,
 /area/f13/brotherhood/surface)
 "vrX" = (
@@ -44790,11 +44775,13 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/building)
 "vCl" = (
-/obj/structure/simple_door/interior,
-/obj/structure/cable{
-	icon_state = "1-2"
+/obj/effect/overlay/desert/sonora/edge{
+	dir = 4
 	},
-/turf/open/floor/plasteel/f13/stone,
+/obj/effect/overlay/desert/sonora/edge,
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "horizontaloutermain2"
+	},
 /area/f13/brotherhood/surface)
 "vCC" = (
 /obj/structure/fence{
@@ -47898,7 +47885,7 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/turf/closed/wall/r_wall/rust,
+/turf/closed/wall/f13/tunnel,
 /area/f13/brotherhood/surface)
 "wYv" = (
 /obj/effect/decal/cleanable/blood/drip,
@@ -98203,7 +98190,7 @@ fWU
 fWU
 xsF
 qQe
-vCl
+vaj
 dgv
 dNF
 prL
@@ -98596,10 +98583,10 @@ wUg
 qCH
 dgv
 eDv
-hDL
+sCc
+eso
+hRy
 wYl
-gyY
-bBH
 dnH
 vwc
 wdg
@@ -98798,13 +98785,13 @@ wdg
 kNx
 qWm
 pRf
-vrW
+bBH
 kAZ
 jMk
 xHd
-sCc
-sCc
-sCc
+uac
+uac
+uac
 aFa
 xHd
 wXe
@@ -99000,13 +98987,13 @@ wdg
 wdg
 wdg
 uix
-hRy
+kVM
+wdg
+vrW
+wdg
+wdg
 wdg
 uac
-wdg
-wdg
-wdg
-sCc
 iyW
 xHd
 wXe
@@ -99202,7 +99189,7 @@ sPy
 sPy
 sPy
 sPy
-vrW
+bBH
 wdg
 jMk
 xHd
@@ -99404,13 +99391,13 @@ sPy
 sPy
 sPy
 gyj
-vrW
+bBH
 wdg
 jMk
-vgj
+vCl
 gjF
 gjF
-ntm
+brU
 gjF
 gjF
 lGU
@@ -99607,14 +99594,14 @@ sPy
 sPy
 sPy
 uix
-mjV
+qUR
 vaj
 tjo
-brU
-brU
-brU
-brU
-brU
+ntm
+ntm
+ntm
+ntm
+ntm
 ayO
 uwi
 uwi
@@ -99811,8 +99798,8 @@ sPy
 dNF
 rqt
 jMk
-qUR
-tjp
+vgj
+mjV
 dKp
 dKp
 dKp
@@ -100209,7 +100196,7 @@ jMk
 kAZ
 dNF
 yek
-kVM
+tjp
 dNF
 tzp
 dNF
@@ -100222,7 +100209,7 @@ fWU
 knR
 fWU
 lhH
-eso
+vaj
 dgv
 wdg
 veg

--- a/_maps/map_files/Blythe-small/blythe-surface.dmm
+++ b/_maps/map_files/Blythe-small/blythe-surface.dmm
@@ -2858,13 +2858,13 @@
 /area/f13/vault)
 "brU" = (
 /obj/structure/cable{
-	icon_state = "1-2"
+	icon_state = "1-4"
+	},
+/obj/structure/cable{
+	icon_state = "1-8"
 	},
 /turf/open/indestructible/ground/outside/desert,
-/turf/open/indestructible/ground/outside/sidewalk{
-	dir = 1;
-	icon_state = "horizontaloutermain1"
-	},
+/turf/open/floor/plasteel/f13/stone,
 /area/f13/brotherhood/surface)
 "bsy" = (
 /turf/open/indestructible/ground/outside/dirt,
@@ -3225,6 +3225,15 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/closed/wall/f13/wood/house,
 /area/f13/ambientlighting/building/p)
+"bBH" = (
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/obj/machinery/light/small{
+	dir = 8
+	},
+/turf/open/floor/plasteel/f13/stone,
+/area/f13/brotherhood/surface)
 "bBS" = (
 /obj/machinery/smartfridge/bottlerack/seedbin,
 /turf/open/floor/wood_common,
@@ -6775,6 +6784,10 @@
 	},
 /area/f13/wasteland/city)
 "dnv" = (
+/obj/machinery/door/airlock/grunge{
+	id_tag = "floor1elevatordoors";
+	req_access_txt = "120"
+	},
 /turf/open/indestructible/ground/outside/desert,
 /turf/open/floor/plasteel/f13/stone,
 /area/f13/brotherhood/surface)
@@ -13352,6 +13365,12 @@
 	icon_state = "wasteland32"
 	},
 /area/f13/wasteland/city)
+"gyY" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/closed/wall/f13/store,
+/area/f13/brotherhood/surface)
 "gzv" = (
 /obj/structure/table,
 /obj/effect/decal/cleanable/dirt,
@@ -16192,10 +16211,11 @@
 	},
 /area/f13/wasteland/city)
 "hRy" = (
-/obj/structure/cable{
-	icon_state = "1-2"
+/obj/machinery/door/airlock/grunge{
+	id_tag = "floor1elevatordoors";
+	req_access_txt = "120"
 	},
-/turf/closed/wall/f13/store,
+/turf/open/floor/plasteel/f13/stone,
 /area/f13/brotherhood/surface)
 "hRD" = (
 /obj/machinery/light{
@@ -22813,12 +22833,9 @@
 /area/f13/building)
 "kVM" = (
 /obj/structure/cable{
-	icon_state = "1-8"
+	icon_state = "0-4"
 	},
-/obj/structure/cable{
-	icon_state = "1-4"
-	},
-/turf/open/indestructible/ground/outside/desert,
+/obj/machinery/power/apc/fusebox/west,
 /turf/open/floor/plasteel/f13/stone,
 /area/f13/brotherhood/surface)
 "kVP" = (
@@ -25437,12 +25454,6 @@
 	},
 /turf/open/floor/carpet/black,
 /area/f13/building/abandoned/a)
-"mjV" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/closed/wall/f13/tunnel,
-/area/f13/brotherhood/surface)
 "mjW" = (
 /obj/effect/landmark/start/f13/ncrspecialist,
 /turf/open/floor/plasteel/f13/stone,
@@ -35377,12 +35388,12 @@
 /area/f13/wasteland/legion)
 "qUR" = (
 /obj/structure/cable{
-	icon_state = "1-2"
+	icon_state = "1-8"
 	},
-/obj/machinery/door/airlock/grunge{
-	id_tag = "floor1elevatordoors";
-	req_access_txt = "120"
+/obj/structure/cable{
+	icon_state = "1-4"
 	},
+/turf/open/indestructible/ground/outside/desert,
 /turf/open/floor/plasteel/f13/stone,
 /area/f13/brotherhood/surface)
 "qVn" = (
@@ -38641,12 +38652,6 @@
 "sBL" = (
 /turf/closed/wall/f13/supermart,
 /area/f13/building/mall)
-"sCc" = (
-/obj/structure/cable{
-	icon_state = "2-4"
-	},
-/turf/open/floor/plasteel/f13/stone,
-/area/f13/brotherhood/surface)
 "sCj" = (
 /mob/living/simple_animal/hostile/ghoul/scorched/ranged,
 /obj/effect/decal/cleanable/dirt,
@@ -40137,20 +40142,17 @@
 /area/f13/building/abandoned/d)
 "tjo" = (
 /obj/structure/cable{
-	icon_state = "1-4"
-	},
-/obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/structure/cable{
-	icon_state = "1-8"
-	},
 /turf/open/indestructible/ground/outside/desert,
-/turf/open/floor/plasteel/f13/stone,
+/turf/open/indestructible/ground/outside/sidewalk{
+	dir = 1;
+	icon_state = "horizontaloutermain1"
+	},
 /area/f13/brotherhood/surface)
 "tjp" = (
 /obj/effect/overlay/desert/sonora/edge{
-	dir = 8
+	dir = 4
 	},
 /turf/open/indestructible/ground/outside/desert,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -41787,10 +41789,6 @@
 /turf/open/floor/wood_common,
 /area/f13/ambientlighting/building/z)
 "uac" = (
-/obj/machinery/power/apc/fusebox/north,
-/obj/structure/cable{
-	icon_state = "0-4"
-	},
 /turf/open/indestructible/ground/outside/desert,
 /turf/open/floor/plasteel/f13/stone,
 /area/f13/brotherhood/surface)
@@ -44011,10 +44009,9 @@
 /area/f13/legioncamp)
 "vgj" = (
 /obj/structure/cable{
-	icon_state = "0-4"
+	icon_state = "1-2"
 	},
-/obj/machinery/power/apc/fusebox/west,
-/turf/open/floor/plasteel/f13/stone,
+/turf/closed/wall/f13/tunnel,
 /area/f13/brotherhood/surface)
 "vgD" = (
 /obj/effect/turf_decal/weather/dirt{
@@ -47680,6 +47677,9 @@
 "wUg" = (
 /obj/machinery/power/terminal,
 /obj/structure/cable,
+/obj/machinery/light/small{
+	dir = 8
+	},
 /turf/open/floor/plasteel/f13/stone,
 /area/f13/brotherhood/surface)
 "wUG" = (
@@ -47865,7 +47865,7 @@
 /area/f13/building/hospital)
 "wYl" = (
 /obj/effect/overlay/desert/sonora/edge{
-	dir = 4
+	dir = 8
 	},
 /turf/open/indestructible/ground/outside/desert,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -98567,11 +98567,11 @@ doD
 wUg
 qCH
 dgv
-vgj
-sCc
+kVM
+bBH
 ntm
-hRy
-mjV
+gyY
+vgj
 dnH
 vwc
 wdg
@@ -98769,14 +98769,14 @@ lVg
 wdg
 kNx
 qWm
-kVM
+qUR
 vrW
 kAZ
 jMk
 xHd
 uac
-dnv
-dnv
+uac
+uac
 aFa
 xHd
 wXe
@@ -98972,13 +98972,13 @@ wdg
 wdg
 wdg
 pRf
-tjo
-eso
-qUR
-eso
-uAf
+brU
 wdg
-dnv
+hRy
+wdg
+wdg
+wdg
+uac
 iyW
 xHd
 wXe
@@ -99175,7 +99175,7 @@ sPy
 sPy
 sPy
 vrW
-kAZ
+wdg
 jMk
 xHd
 xHd
@@ -99377,12 +99377,12 @@ sPy
 sPy
 gyj
 vrW
-kAZ
+wdg
 jMk
 gjF
 gjF
 gjF
-wYl
+tjp
 gjF
 gjF
 lGU
@@ -99581,12 +99581,12 @@ sPy
 pRf
 uix
 vaj
-brU
-brU
-brU
-brU
-brU
-brU
+tjo
+tjo
+tjo
+tjo
+tjo
+tjo
 ayO
 uwi
 uwi
@@ -99784,7 +99784,7 @@ dNF
 rqt
 jMk
 dKp
-tjp
+wYl
 dKp
 dKp
 dKp

--- a/_maps/map_files/Blythe-small/blythe-upper.dmm
+++ b/_maps/map_files/Blythe-small/blythe-upper.dmm
@@ -921,6 +921,13 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/showroomfloor,
 /area/f13/followers)
+"ex" = (
+/obj/structure/destructible/tribal_torch/wall/lit{
+	dir = 8;
+	light_color = "#f4e3b0"
+	},
+/turf/open/floor/plasteel/f13,
+/area/f13/wasteland)
 "ey" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "000000"
@@ -9722,15 +9729,6 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/building/mall)
-"Uq" = (
-/obj/machinery/power/port_gen/pacman/diesel{
-	anchored = 1
-	},
-/obj/structure/cable{
-	icon_state = "0-8"
-	},
-/turf/open/floor/plasteel/f13/stone,
-/area/f13/wasteland)
 "Ur" = (
 /obj/machinery/light{
 	dir = 4
@@ -9829,6 +9827,15 @@
 	icon_state = "darkrustysolid"
 	},
 /area/f13/wasteland/ncr)
+"UL" = (
+/obj/machinery/power/port_gen/pacman/diesel{
+	anchored = 1
+	},
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
+/turf/open/floor/plasteel/f13/stone,
+/area/f13/wasteland)
 "UM" = (
 /obj/structure/railing/corner,
 /turf/open/floor/f13{
@@ -58011,7 +58018,7 @@ Cb
 Cb
 Cb
 kY
-Jf
+um
 Jf
 Jf
 Jf
@@ -58213,7 +58220,7 @@ Cb
 Cb
 Cb
 kY
-lj
+ex
 Bn
 ur
 bV
@@ -59632,7 +59639,7 @@ QU
 lj
 lj
 rK
-Uq
+UL
 Wq
 Wq
 mg

--- a/_maps/map_files/Blythe-small/blythe-upper.dmm
+++ b/_maps/map_files/Blythe-small/blythe-upper.dmm
@@ -9722,6 +9722,15 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/building/mall)
+"Uq" = (
+/obj/machinery/power/port_gen/pacman/diesel{
+	anchored = 1
+	},
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
+/turf/open/floor/plasteel/f13/stone,
+/area/f13/wasteland)
 "Ur" = (
 /obj/machinery/light{
 	dir = 4
@@ -10340,7 +10349,6 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/stone,
 /area/f13/wasteland)
 "WQ" = (
@@ -59624,7 +59632,7 @@ QU
 lj
 lj
 rK
-Wq
+Uq
 Wq
 Wq
 mg

--- a/_maps/map_files/Blythe-small/blythe-upper.dmm
+++ b/_maps/map_files/Blythe-small/blythe-upper.dmm
@@ -36,6 +36,13 @@
 	},
 /turf/open/indestructible/ground/inside/dirt,
 /area/f13/wasteland/ncr)
+"ah" = (
+/obj/structure/destructible/tribal_torch/wall/lit{
+	dir = 8;
+	light_color = "#f4e3b0"
+	},
+/turf/open/floor/plasteel/f13,
+/area/f13/wasteland)
 "ai" = (
 /obj/structure/toilet{
 	dir = 1
@@ -921,13 +928,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/showroomfloor,
 /area/f13/followers)
-"ex" = (
-/obj/structure/destructible/tribal_torch/wall/lit{
-	dir = 8;
-	light_color = "#f4e3b0"
-	},
-/turf/open/floor/plasteel/f13,
-/area/f13/wasteland)
 "ey" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "000000"
@@ -1125,10 +1125,10 @@
 /turf/open/floor/carpet/green,
 /area/f13/ambientlighting/building/j)
 "fx" = (
-/obj/structure/cable{
-	icon_state = "2-8"
-	},
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/chair/stool{
+	pixel_y = 6
+	},
 /turf/open/floor/plasteel/f13,
 /area/f13/wasteland)
 "fy" = (
@@ -2464,9 +2464,7 @@
 /turf/closed/wall/f13/supermart,
 /area/f13/building/mall)
 "lB" = (
-/obj/structure/cable{
-	icon_state = "1-4"
-	},
+/obj/machinery/hydroponics/constructable,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13,
@@ -3097,6 +3095,7 @@
 /obj/structure/table/reinforced{
 	color = "#c1b6a5"
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13,
 /area/f13/wasteland)
 "oO" = (
@@ -3294,6 +3293,7 @@
 /obj/effect/decal/cleanable/dirt{
 	color = "#363636"
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13,
 /area/f13/wasteland)
 "pI" = (
@@ -4673,10 +4673,11 @@
 /turf/open/floor/f13/wood,
 /area/f13/building/mall)
 "vH" = (
+/obj/structure/table/wood,
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light{
-	dir = 4
+/obj/item/reagent_containers/food/drinks/mug{
+	pixel_x = 2;
+	pixel_y = 7
 	},
 /turf/open/floor/plasteel/f13,
 /area/f13/wasteland)
@@ -4706,8 +4707,12 @@
 /turf/open/floor/plasteel/f13/vault_floor/purple,
 /area/f13/building/hospital)
 "vO" = (
+/obj/structure/table/wood,
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/light,
+/obj/effect/decal/cleanable/dirt,
+/obj/item/storage/box/drinkingglasses{
+	pixel_y = 2
+	},
 /turf/open/floor/plasteel/f13,
 /area/f13/wasteland)
 "vP" = (
@@ -7654,6 +7659,15 @@
 /obj/effect/decal/cleanable/blood/drip,
 /turf/closed/wall/f13/wood/house,
 /area/f13/ambientlighting/building/j)
+"JF" = (
+/obj/machinery/power/port_gen/pacman/diesel{
+	anchored = 1
+	},
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
+/turf/open/floor/plasteel/f13/stone,
+/area/f13/wasteland)
 "JG" = (
 /obj/structure/displaycase/trophy,
 /obj/item/gun/ballistic/shotgun/automatic/combat/shotgunlever,
@@ -9827,15 +9841,6 @@
 	icon_state = "darkrustysolid"
 	},
 /area/f13/wasteland/ncr)
-"UL" = (
-/obj/machinery/power/port_gen/pacman/diesel{
-	anchored = 1
-	},
-/obj/structure/cable{
-	icon_state = "0-8"
-	},
-/turf/open/floor/plasteel/f13/stone,
-/area/f13/wasteland)
 "UM" = (
 /obj/structure/railing/corner,
 /turf/open/floor/f13{
@@ -10786,6 +10791,12 @@
 	name = "air";
 	sunlight_state = 1
 	},
+/area/f13/wasteland)
+"Zc" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light,
+/obj/structure/table/wood,
+/turf/open/floor/plasteel/f13,
 /area/f13/wasteland)
 "Ze" = (
 /turf/open/floor/wood_common,
@@ -58220,7 +58231,7 @@ Cb
 Cb
 Cb
 kY
-ex
+ah
 Bn
 ur
 bV
@@ -58229,14 +58240,14 @@ lj
 De
 lj
 lj
+rK
+rK
 lj
 lj
 lj
+rK
 lj
 lj
-eA
-vH
-eq
 lj
 lj
 lj
@@ -58431,16 +58442,16 @@ vM
 wV
 lj
 oM
-lj
-pG
-lj
-tv
-lj
-vO
-af
-NM
 rK
+pG
 eq
+lB
+eq
+eA
+Bn
+vH
+fx
+lj
 eA
 eq
 eA
@@ -58637,12 +58648,12 @@ rK
 lj
 eq
 eq
-eq
-eq
-xN
-eq
-eq
 eA
+rK
+Bn
+vO
+fx
+eq
 ku
 ro
 pt
@@ -58839,12 +58850,12 @@ rK
 tv
 rK
 iT
-lj
-lj
+rK
+rK
 fx
-JK
-lB
-eq
+Zc
+af
+NM
 DF
 af
 NM
@@ -59042,10 +59053,10 @@ rK
 Xr
 rK
 rK
+eq
 rK
-rK
-lj
-nZ
+eq
+xN
 eq
 eq
 Lj
@@ -59639,7 +59650,7 @@ QU
 lj
 lj
 rK
-UL
+JF
 Wq
 Wq
 mg


### PR DESCRIPTION
## About The Pull Request
Fixes the surface BoS trading point.
Adds the reloading bench to khans
![image](https://github.com/Afterglow-Ss13/afterglow-ss13/assets/93557430/8a556d34-92c9-47be-aca3-5f03c7c8ee7a)
![image](https://github.com/Afterglow-Ss13/afterglow-ss13/assets/93557430/d8338567-0d51-402a-be9e-cc4425252814)


## Pre-Merge Checklist
- [X] You tested this on a local server.
- [X] This code did not runtime during testing.
- [X] You documented all of your changes.
<!-- Tick these after making the PR. -->

## Changelog
:cl:
tweak: Fixes the cables
add: reloading bench to the khans area
/:cl: