### PR TITLE
Medicine rebalance (bear and bull made equal)

### DIFF
--- a/code/datums/components/crafting/recipes/recipes_medicine.dm
+++ b/code/datums/components/crafting/recipes/recipes_medicine.dm
@@ -111,27 +111,35 @@
 /datum/crafting_recipe/bitterdrink
 	name = "Bottle bitterdrink"
 	result = /obj/item/reagent_containers/pill/bitterdrink
-	reqs = list(/obj/item/reagent_containers/food/snacks/grown/broc = 1,
-				/obj/item/reagent_containers/food/snacks/grown/xander = 1,
-				/obj/item/reagent_containers/food/drinks/bottle = 1)
+	reqs = list(/obj/item/reagent_containers/food/snacks/grown/broc = 2,
+				/obj/item/reagent_containers/food/snacks/grown/xander = 2,
+				/obj/item/reagent_containers/food/snacks/grown/agave = 1,
+				/obj/item/reagent_containers/food/snacks/grown/fungus = 1,
+				/obj/item/stack/sheet/leather = 1,
+				/datum/reagent/consumable/nuka_cola = 25,
+				/datum/reagent/radium = 5)
 	tools = list(TOOL_ALCHEMY_TABLE)
 	time = 10
 	category = CAT_MEDICAL
 	skill_needed = SKILL_OUTDOORSMAN
-	skill_level = REGULAR_CHECK
+	skill_level = HARD_CHECK
 
 /datum/crafting_recipe/bitterdrink5
 	name = "Batch of bitterdrink (x5)"
 	result = /obj/item/storage/box/medicine/bitterdrink5
-	reqs = list(/obj/item/reagent_containers/food/snacks/grown/broc = 5,
-				/obj/item/reagent_containers/food/snacks/grown/xander = 5,
-				/obj/item/reagent_containers/food/drinks/bottle = 5)
+	reqs = list(/obj/item/reagent_containers/food/snacks/grown/broc = 10,
+				/obj/item/reagent_containers/food/snacks/grown/xander = 10,
+				/obj/item/reagent_containers/food/snacks/grown/agave = 5,
+				/obj/item/reagent_containers/food/snacks/grown/fungus = 5,
+				/obj/item/stack/sheet/leather = 5,
+				/datum/reagent/consumable/nuka_cola = 125,
+				/datum/reagent/radium = 25)
 	tools = list(TOOL_ALCHEMY_TABLE)
 	time = 20
 	category = CAT_MEDICAL
 	always_available = FALSE
 	skill_needed = SKILL_OUTDOORSMAN
-	skill_level = REGULAR_CHECK
+	skill_level = HARD_CHECK
 
 /datum/crafting_recipe/healpoultice
 	name = "Healing poultice"
@@ -144,7 +152,7 @@
 	time = 10
 	category = CAT_MEDICAL
 	skill_needed = SKILL_OUTDOORSMAN
-	skill_level = EASY_CHECK
+	skill_level = REGULAR_CHECK
 
 /datum/crafting_recipe/healpoultice5
 	name = "Batch of healing poultice (x5)"
@@ -157,7 +165,7 @@
 	time = 20
 	category = CAT_MEDICAL
 	skill_needed = SKILL_OUTDOORSMAN
-	skill_level = EASY_CHECK
+	skill_level = REGULAR_CHECK
 
 /datum/crafting_recipe/smell_salts
 	name = "Smelling salts"

--- a/code/modules/fallout/reagents/medicines.dm
+++ b/code/modules/fallout/reagents/medicines.dm
@@ -1,5 +1,5 @@
 /* 
- * Stimpak Juice
+ * Fallout 13 generic medicine, stimpak/poultice
  * Some lingering heal over time
  * Heals either brute or burn per tick, whichever's higher
  * Overdose makes you barf stunlock yourself
@@ -11,7 +11,7 @@
 	color = "#eb0000"
 	taste_description = "numbness"
 	metabolization_rate = 5 * REAGENTS_METABOLISM
-	overdose_threshold = 30
+	overdose_threshold = 50
 	value = REAGENT_VALUE_COMMON
 	ghoulfriendly = TRUE
 
@@ -32,9 +32,9 @@
 // heals 1 damage of either brute or burn on life, whichever's higher
 /datum/reagent/medicine/stimpak/on_mob_life(mob/living/carbon/M)
 	if(M.getBruteLoss() > M.getFireLoss())	//Less effective at healing mixed damage types.
-		M.adjustBruteLoss(-2*REAGENTS_EFFECT_MULTIPLIER)
+		M.adjustBruteLoss(-3*REAGENTS_EFFECT_MULTIPLIER)
 	else
-		M.adjustFireLoss(-2*REAGENTS_EFFECT_MULTIPLIER)
+		M.adjustFireLoss(-3*REAGENTS_EFFECT_MULTIPLIER)
 	. = TRUE
 	..()
 
@@ -58,8 +58,8 @@
 	reagent_state = LIQUID
 	color = "#e50d0d"
 	taste_description = "numbness"
-	metabolization_rate = 3 * REAGENTS_METABOLISM	// 50 seconds, same as poultice
-	overdose_threshold = 40	// you can risk a second dose
+	metabolization_rate = 5 * REAGENTS_METABOLISM
+	overdose_threshold = 50
 	ghoulfriendly = TRUE
 	var/clot_rate = 0.10
 	var/clot_coeff_per_wound = 0.7
@@ -90,9 +90,9 @@
 
 /// Seals up bleeds like a weaker sanguirite, doesnt do any passive heals though
 /datum/reagent/medicine/super_stimpak/on_mob_life(mob/living/carbon/M) // Heals fleshwounds like a weak sanguirite
-	M.adjustBruteLoss(-1*REAGENTS_EFFECT_MULTIPLIER)
-	M.adjustFireLoss(-1*REAGENTS_EFFECT_MULTIPLIER)
-	M.adjustToxLoss(-1*REAGENTS_EFFECT_MULTIPLIER)
+	M.adjustBruteLoss(-2*REAGENTS_EFFECT_MULTIPLIER)
+	M.adjustFireLoss(-2*REAGENTS_EFFECT_MULTIPLIER)
+	M.adjustToxLoss(-2*REAGENTS_EFFECT_MULTIPLIER)
 	clot_bleed_wounds(user = M, bleed_reduction_rate = clot_rate, coefficient_per_wound = clot_coeff_per_wound, single_wound_full_effect = FALSE)
 	. = TRUE
 	..()
@@ -159,8 +159,8 @@
 	reagent_state = SOLID
 	color = "#A9FBFB"
 	taste_description = "bitterness"
-	metabolization_rate = 1 * REAGENTS_METABOLISM	// same as bicaridine
-	overdose_threshold = 30
+	metabolization_rate = 2.5 * REAGENTS_METABOLISM
+	overdose_threshold = 25
 	ghoulfriendly = TRUE
 
 /datum/reagent/medicine/healing_powder/on_mob_life(mob/living/carbon/M)
@@ -188,7 +188,8 @@
 	name = "Bitter drink"
 	description = "Potent, stinging herbs that swiftly aid in the recovery of grevious wounds."
 	color = "#C8A5DC"
-	overdose_threshold = 12
+	overdose_threshold = 50
+	metabolization_rate = 5 * REAGENTS_METABOLISM
 	var/clot_rate = 0.10
 	var/clot_coeff_per_wound = 0.7
 
@@ -204,9 +205,9 @@
 
 /datum/reagent/medicine/healing_powder/bitterdrink/on_mob_life(mob/living/carbon/M)
 	. = ..()
-	M.adjustBruteLoss(-1*REAGENTS_EFFECT_MULTIPLIER)
-	M.adjustFireLoss(-1*REAGENTS_EFFECT_MULTIPLIER)
-	M.adjustToxLoss(-1*REAGENTS_EFFECT_MULTIPLIER)
+	M.adjustBruteLoss(-2*REAGENTS_EFFECT_MULTIPLIER)
+	M.adjustFireLoss(-2*REAGENTS_EFFECT_MULTIPLIER)
+	M.adjustToxLoss(-2*REAGENTS_EFFECT_MULTIPLIER)
 	clot_bleed_wounds(user = M, bleed_reduction_rate = clot_rate, coefficient_per_wound = clot_coeff_per_wound, single_wound_full_effect = FALSE)
 	. = TRUE
 	..()

--- a/code/modules/fallout/reagents/medicines.dm
+++ b/code/modules/fallout/reagents/medicines.dm
@@ -1,40 +1,40 @@
 /* 
  * Stimpak Juice
- * Initial insta-heal
  * Some lingering heal over time
  * Heals either brute or burn per tick, whichever's higher
  * Overdose makes you barf stunlock yourself
  */
 /datum/reagent/medicine/stimpak	// Supplemented by other chems within a stimpak
-	name = "Stimfluid"
+	name = "Medicinal fluid"
 	description = "A cocktail of advanced medicines designed to rapidly heal wounds."
 	reagent_state = LIQUID
 	color = "#eb0000"
 	taste_description = "numbness"
 	metabolization_rate = 5 * REAGENTS_METABOLISM
-	overdose_threshold = 60
+	overdose_threshold = 30
 	value = REAGENT_VALUE_COMMON
 	ghoulfriendly = TRUE
 
 // insta-heal on inject, 1 of each brute and burn per volume
-/datum/reagent/medicine/stimpak/reaction_mob(mob/living/M, method=INJECT, reac_volume)
-	if(iscarbon(M))
-		if(M.stat == DEAD) // Doesnt work on the dead
-			return
-		if(method != INJECT) // Gotta be injected
-			return
-		if(M.getBruteLoss())
-			M.adjustBruteLoss(-reac_volume)
-		if(M.getFireLoss())
-			M.adjustFireLoss(-reac_volume)
-	..()
+
+///datum/reagent/medicine/stimpak/reaction_mob(mob/living/M, method=INJECT, reac_volume)
+//	if(iscarbon(M))
+//		if(M.stat == DEAD) // Doesnt work on the dead
+//			return
+//		if(method != INJECT) // Gotta be injected
+//			return
+//		if(M.getBruteLoss())
+//			M.adjustBruteLoss(-reac_volume)
+//		if(M.getFireLoss())
+//			M.adjustFireLoss(-reac_volume)
+//	..()
 
 // heals 1 damage of either brute or burn on life, whichever's higher
 /datum/reagent/medicine/stimpak/on_mob_life(mob/living/carbon/M)
 	if(M.getBruteLoss() > M.getFireLoss())	//Less effective at healing mixed damage types.
-		M.adjustBruteLoss(-1*REAGENTS_EFFECT_MULTIPLIER)
+		M.adjustBruteLoss(-2*REAGENTS_EFFECT_MULTIPLIER)
 	else
-		M.adjustFireLoss(-1*REAGENTS_EFFECT_MULTIPLIER)
+		M.adjustFireLoss(-2*REAGENTS_EFFECT_MULTIPLIER)
 	. = TRUE
 	..()
 
@@ -47,7 +47,7 @@
 
 /* 
  * Super Stimpak Juice
- * Initial insta-heal
+ * Heals over time
  * Fixes up cuts like a weaker sanguirite
  * Overdose makes your heart die
  */
@@ -64,17 +64,17 @@
 	var/clot_rate = 0.10
 	var/clot_coeff_per_wound = 0.7
 
-/datum/reagent/medicine/super_stimpak/reaction_mob(mob/living/M, method=INJECT, reac_volume)
-	if(iscarbon(M))
-		if(M.stat == DEAD)
-			return
-		if(method != INJECT)
-			return
-		if(M.getBruteLoss())
-			M.adjustBruteLoss(-reac_volume)
-		if(M.getFireLoss())
-			M.adjustFireLoss(-reac_volume)
-	..()
+///datum/reagent/medicine/super_stimpak/reaction_mob(mob/living/M, method=INJECT, reac_volume)
+//	if(iscarbon(M))
+//		if(M.stat == DEAD)
+//			return
+//		if(method != INJECT)
+//			return
+//		if(M.getBruteLoss())
+//			M.adjustBruteLoss(-reac_volume)
+//		if(M.getFireLoss())
+//			M.adjustFireLoss(-reac_volume)
+//	..()
 
 /// Slows you down and tells you that your heart's gonna get wrecked if you keep taking more
 /datum/reagent/medicine/super_stimpak/on_mob_metabolize(mob/living/carbon/M) // Stim Sickness
@@ -90,6 +90,9 @@
 
 /// Seals up bleeds like a weaker sanguirite, doesnt do any passive heals though
 /datum/reagent/medicine/super_stimpak/on_mob_life(mob/living/carbon/M) // Heals fleshwounds like a weak sanguirite
+	M.adjustBruteLoss(-1*REAGENTS_EFFECT_MULTIPLIER)
+	M.adjustFireLoss(-1*REAGENTS_EFFECT_MULTIPLIER)
+	M.adjustToxLoss(-1*REAGENTS_EFFECT_MULTIPLIER)
 	clot_bleed_wounds(user = M, bleed_reduction_rate = clot_rate, coefficient_per_wound = clot_coeff_per_wound, single_wound_full_effect = FALSE)
 	. = TRUE
 	..()
@@ -174,32 +177,32 @@
 	..()
 
 /* 
- * Healing Poultice
+ * Bitter drink
  * Heals both brute and burn
  * Seals up cuts
  * Overdose poisons you
  * Ghouls love it
  */
 
-/datum/reagent/medicine/healing_powder/poultice	// Handles superior healing of the poultice herbal mix, with its superior healing, wound recovery, and painful OD
-	name = "Healing poultice"
+/datum/reagent/medicine/healing_powder/bitterdrink	// Handles superior healing of bitter drinks, with its superior healing, wound recovery, and painful OD
+	name = "Bitter drink"
 	description = "Potent, stinging herbs that swiftly aid in the recovery of grevious wounds."
 	color = "#C8A5DC"
 	overdose_threshold = 12
 	var/clot_rate = 0.10
 	var/clot_coeff_per_wound = 0.7
 
-/datum/reagent/medicine/healing_powder/poultice/on_mob_metabolize(mob/living/carbon/M) // a painful remedy!
+/datum/reagent/medicine/healing_powder/bitterdrink/on_mob_metabolize(mob/living/carbon/M) // a painful remedy!
 	. = ..()
 	M.add_movespeed_modifier(/datum/movespeed_modifier/healing_poultice_slowdown)
-	to_chat(M, span_alert("You feel a burning pain spread through your skin, concentrating around your wounds."))
+	to_chat(M, span_alert("You taste an unbearable bitterness. It makes you feel sick."))
 
-/datum/reagent/medicine/healing_powder/poultice/on_mob_end_metabolize(mob/living/carbon/M)
+/datum/reagent/medicine/healing_powder/bitterdrink/on_mob_end_metabolize(mob/living/carbon/M)
 	. = ..()
 	M.remove_movespeed_modifier(/datum/movespeed_modifier/healing_poultice_slowdown)
-	to_chat(M, span_notice("The poultice's burning subsides."))
+	to_chat(M, span_notice("The bitter taste in your mouth subsides."))
 
-/datum/reagent/medicine/healing_powder/poultice/on_mob_life(mob/living/carbon/M)
+/datum/reagent/medicine/healing_powder/bitterdrink/on_mob_life(mob/living/carbon/M)
 	. = ..()
 	M.adjustBruteLoss(-1*REAGENTS_EFFECT_MULTIPLIER)
 	M.adjustFireLoss(-1*REAGENTS_EFFECT_MULTIPLIER)
@@ -209,14 +212,14 @@
 	..()
 
 
-/datum/reagent/medicine/healing_powder/poultice/overdose_process(mob/living/carbon/M)
+/datum/reagent/medicine/healing_powder/bitterdrink/overdose_process(mob/living/carbon/M)
 	M.adjustToxLoss(4)
 	if((M.getToxLoss() >= 30) && prob(8))
-		var/poultice_od_message = pick(
-			"Burning red streaks form on your skin.", 
-			"You feel a searing pain shoot through your skin.",
-			"You feel like your blood's been replaced with acid. It burns.")
-		to_chat(M, span_notice("[poultice_od_message]"))
+		var/bitterdrink_od_message = pick(
+			"You feel extremely sick.", 
+			"You feel a searing pain in your stomach.",
+			"You feel like your suffering from a gastrointestinal bleed. It burns.")
+		to_chat(M, span_notice("[bitterdrink_od_message]"))
 	. = TRUE
 	..()
 

--- a/code/modules/reagents/reagent_containers/hypospray.dm
+++ b/code/modules/reagents/reagent_containers/hypospray.dm
@@ -152,7 +152,7 @@
 // FALLOUT HYPOS //
 ///////////////////
 
-/obj/item/reagent_containers/hypospray/medipen/stimpak // ~50 hp over 20 seconds. stims in fallout contain a whole cocktail of chems, and this mix prevents them from stacking with healing powder and bitter drink.
+/obj/item/reagent_containers/hypospray/medipen/stimpak // Heals 7 damage on life, includes bicardine and kelotane so it doesn't stack with either.
 	name = "stimpak"
 	desc = "A handheld delivery system for medicine, used to rapidly heal physical damage to the body."
 	icon = 'icons/fallout/objects/medicine/drugs.dmi'
@@ -161,7 +161,7 @@
 	volume = 26
 	amount_per_transfer_from_this = 26
 	reagent_flags = DRAWABLE
-	list_reagents = list(/datum/reagent/medicine/stimpak = 20, /datum/reagent/medicine/healing_powder = 3, /datum/reagent/medicine/bicaridine = 3, /datum/reagent/medicine/kelotane = 3)
+	list_reagents = list(/datum/reagent/medicine/stimpak = 20, /datum/reagent/medicine/healing_powder = 10, /datum/reagent/medicine/bicaridine = 5, /datum/reagent/medicine/kelotane = 5)
 
 /obj/item/reagent_containers/hypospray/medipen/stimpak/on_reagent_change(changetype)
 	update_icon()
@@ -195,14 +195,14 @@
 // ---------------------------------
 // SUPER STIMPAK
 
-/obj/item/reagent_containers/hypospray/medipen/stimpak/super // ~100 hp over 50 seconds.
+/obj/item/reagent_containers/hypospray/medipen/stimpak/super // Heals 9 HP on life and fixes wounds, 2 more than regular stims at the cost of slowdown.
 	name = "super stimpak"
 	desc = "The super version comes in a hypodermic, but with an additional vial containing more powerful drugs than the basic model and a leather belt to strap the needle to the injured limb."
 	icon_state = "hypo_superstimpak"
 	custom_price = PRICE_SUPER_STIM
 	volume = 62
 	amount_per_transfer_from_this = 62
-	list_reagents = list(/datum/reagent/medicine/super_stimpak = 30, /datum/reagent/medicine/stimpak = 20, /datum/reagent/medicine/healing_powder = 6, /datum/reagent/medicine/bicaridine = 6, /datum/reagent/medicine/kelotane = 6)
+	list_reagents = list(/datum/reagent/medicine/super_stimpak = 20, /datum/reagent/medicine/stimpak = 20, /datum/reagent/medicine/healing_powder = 10, /datum/reagent/medicine/bicaridine = 5, /datum/reagent/medicine/kelotane = 5)
 
 /obj/item/reagent_containers/hypospray/medipen/stimpak/super/custom
 	desc = "The super version comes in a hypodermic, but with an additional vial to inject more drugs than the basic model and a leather belt to strap the needle to a limb. This particular one will deliver a tailored cocktail."

--- a/code/modules/reagents/reagent_containers/hypospray.dm
+++ b/code/modules/reagents/reagent_containers/hypospray.dm
@@ -152,7 +152,7 @@
 // FALLOUT HYPOS //
 ///////////////////
 
-/obj/item/reagent_containers/hypospray/medipen/stimpak // 20hp instantly, plus 30hp over 20 seconds. stims in fallout contain a whole cocktail of chems, and this mix prevents them from stacking with healing powder and bitter drink.
+/obj/item/reagent_containers/hypospray/medipen/stimpak // ~50 hp over 20 seconds. stims in fallout contain a whole cocktail of chems, and this mix prevents them from stacking with healing powder and bitter drink.
 	name = "stimpak"
 	desc = "A handheld delivery system for medicine, used to rapidly heal physical damage to the body."
 	icon = 'icons/fallout/objects/medicine/drugs.dmi'
@@ -161,7 +161,7 @@
 	volume = 26
 	amount_per_transfer_from_this = 26
 	reagent_flags = DRAWABLE
-	list_reagents = list(/datum/reagent/medicine/stimpak = 20, /datum/reagent/medicine/healing_powder = 2, /datum/reagent/medicine/bicaridine = 2, /datum/reagent/medicine/kelotane = 2)
+	list_reagents = list(/datum/reagent/medicine/stimpak = 20, /datum/reagent/medicine/healing_powder = 3, /datum/reagent/medicine/bicaridine = 3, /datum/reagent/medicine/kelotane = 3)
 
 /obj/item/reagent_containers/hypospray/medipen/stimpak/on_reagent_change(changetype)
 	update_icon()
@@ -195,14 +195,14 @@
 // ---------------------------------
 // SUPER STIMPAK
 
-/obj/item/reagent_containers/hypospray/medipen/stimpak/super // 50hp instantly, plus 50hp over 20 seconds.
+/obj/item/reagent_containers/hypospray/medipen/stimpak/super // ~100 hp over 50 seconds.
 	name = "super stimpak"
 	desc = "The super version comes in a hypodermic, but with an additional vial containing more powerful drugs than the basic model and a leather belt to strap the needle to the injured limb."
 	icon_state = "hypo_superstimpak"
 	custom_price = PRICE_SUPER_STIM
 	volume = 62
 	amount_per_transfer_from_this = 62
-	list_reagents = list(/datum/reagent/medicine/super_stimpak = 30, /datum/reagent/medicine/stimpak = 20, /datum/reagent/medicine/healing_powder = 4, /datum/reagent/medicine/bicaridine = 4, /datum/reagent/medicine/kelotane = 4)
+	list_reagents = list(/datum/reagent/medicine/super_stimpak = 30, /datum/reagent/medicine/stimpak = 20, /datum/reagent/medicine/healing_powder = 6, /datum/reagent/medicine/bicaridine = 6, /datum/reagent/medicine/kelotane = 6)
 
 /obj/item/reagent_containers/hypospray/medipen/stimpak/super/custom
 	desc = "The super version comes in a hypodermic, but with an additional vial to inject more drugs than the basic model and a leather belt to strap the needle to a limb. This particular one will deliver a tailored cocktail."

--- a/code/modules/reagents/reagent_containers/patch.dm
+++ b/code/modules/reagents/reagent_containers/patch.dm
@@ -78,7 +78,7 @@
 	icon = 'icons/fallout/objects/medicine/drugs.dmi'
 	icon_state = "patch_healingpowder"
 	list_reagents = list(/datum/reagent/medicine/healing_powder = 10)
-	self_delay = 5
+	self_delay = 0
 
 // ---------------------------------
 // CUSTOM POWDER
@@ -89,30 +89,31 @@
 	list_reagents = null
 	icon = 'icons/fallout/objects/medicine/drugs.dmi'
 	icon_state = "patch_healingpowder"
-	self_delay = 5
 	color = COLOR_PALE_GREEN_GRAY
+	self_delay = 0
 
 // ---------------------------------
 // HEALING POULTICE
 
-/obj/item/reagent_containers/pill/patch/healpoultice // 100hp over 50 seconds. a bit more potent than just bitters.
+/obj/item/reagent_containers/pill/patch/healpoultice // ~50hp over 20 seconds. Functionally identical to stimpaks.
 	name = "Healing poultice"
 	desc = "A concoction of broc flower, cave fungus, agrave fruit and xander root."
 	icon = 'icons/fallout/objects/medicine/drugs.dmi'
-	list_reagents = list(/datum/reagent/medicine/healing_powder/poultice = 10, /datum/reagent/medicine/healing_powder = 10, /datum/reagent/medicine/bicaridine = 5, /datum/reagent/medicine/kelotane = 5)
+	list_reagents = list(/datum/reagent/medicine/stimpak = 20, /datum/reagent/medicine/healing_powder = 3, /datum/reagent/medicine/bicaridine = 3, /datum/reagent/medicine/kelotane = 3)
 	icon_state = "patch_healingpoultice"
-	self_delay = 5
+	self_delay = 0
 
 // ---------------------------------
 // BITTER DRINK
 
-/obj/item/reagent_containers/pill/bitterdrink // 50hp over 25 seconds
+/obj/item/reagent_containers/pill/bitterdrink // ~100hp over 50 seconds. Identical to super stimpaks, aside from using bitter drink instead of super stimfluid.
+	name = "Healing poultice"
 	name = "Bitter drink"
 	desc = "A strong herbal healing concoction invented and created by the Twin Mothers tribe."
 	icon = 'icons/fallout/objects/medicine/drugs.dmi'
 	icon_state = "patch_bitterdrink"
-	list_reagents = list(/datum/reagent/medicine/healing_powder = 5, /datum/reagent/medicine/bicaridine = 5, /datum/reagent/medicine/kelotane = 5) 
-	self_delay = 5
+	list_reagents = list(/datum/reagent/medicine/healing_powder/bitterdrink = 10, /datum/reagent/medicine/stimpak = 20, /datum/reagent/medicine/healing_powder = 6, /datum/reagent/medicine/bicaridine = 6, /datum/reagent/medicine/kelotane = 6) 
+	self_delay = 0
 
 // ---------------------------------
 // HYDRA - never a thing, make it something. Sprites done.

--- a/code/modules/reagents/reagent_containers/patch.dm
+++ b/code/modules/reagents/reagent_containers/patch.dm
@@ -95,24 +95,24 @@
 // ---------------------------------
 // HEALING POULTICE
 
-/obj/item/reagent_containers/pill/patch/healpoultice // ~50hp over 20 seconds. Functionally identical to stimpaks.
+/obj/item/reagent_containers/pill/patch/healpoultice // Tribal stimpaks.
 	name = "Healing poultice"
 	desc = "A concoction of broc flower, cave fungus, agrave fruit and xander root."
 	icon = 'icons/fallout/objects/medicine/drugs.dmi'
-	list_reagents = list(/datum/reagent/medicine/stimpak = 20, /datum/reagent/medicine/healing_powder = 3, /datum/reagent/medicine/bicaridine = 3, /datum/reagent/medicine/kelotane = 3)
+	list_reagents = list(/datum/reagent/medicine/stimpak = 20, /datum/reagent/medicine/healing_powder = 10, /datum/reagent/medicine/bicaridine = 5, /datum/reagent/medicine/kelotane = 5)
 	icon_state = "patch_healingpoultice"
 	self_delay = 0
 
 // ---------------------------------
 // BITTER DRINK
 
-/obj/item/reagent_containers/pill/bitterdrink // ~100hp over 50 seconds. Identical to super stimpaks, aside from using bitter drink instead of super stimfluid.
+/obj/item/reagent_containers/pill/bitterdrink // Tribal super stims.
 	name = "Healing poultice"
 	name = "Bitter drink"
 	desc = "A strong herbal healing concoction invented and created by the Twin Mothers tribe."
 	icon = 'icons/fallout/objects/medicine/drugs.dmi'
 	icon_state = "patch_bitterdrink"
-	list_reagents = list(/datum/reagent/medicine/healing_powder/bitterdrink = 10, /datum/reagent/medicine/stimpak = 20, /datum/reagent/medicine/healing_powder = 6, /datum/reagent/medicine/bicaridine = 6, /datum/reagent/medicine/kelotane = 6) 
+	list_reagents = list(/datum/reagent/medicine/healing_powder/bitterdrink = 20, /datum/reagent/medicine/stimpak = 20, /datum/reagent/medicine/healing_powder = 10, /datum/reagent/medicine/bicaridine = 5, /datum/reagent/medicine/kelotane = 5) 
 	self_delay = 0
 
 // ---------------------------------


### PR DESCRIPTION
## About The Pull Request
Makes it so that tribal fallout medicine is as good as regular fallout medicine, for bear bull purposes. It changes the name of stimfluid so that scanners won't show "stimfluid" when the bitters women scan a legionary, then makes poultice functionally identical to stims. The same is done with bitter drinks where the old poultice reagent stays the same and is renamed to bitter drink, and made equal with super stims. Instant heals are removed entirely because lol whose idea was that. Overall healing values stay almost the same, with a slight increase.

Forgot to mention this:
The recipes for tribal medicine have been updated as well to match stims and super stims. The tribal variants are a bit more expensive. The level of outdoorsman required to craft bitter drinks and poultices has been increased to the next tier for each as well.

## Pre-Merge Checklist
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
<!-- Tick these after making the PR. -->

## Changelog
:cl:
del: instant heal on stimfluids
tweak: poultice reagent renamed to bitter drink
tweak: added stim fluid, now renamed "medical fluid" to poultices
tweak: changed the properties of super stim fluid to be similar to the old poultice reagent
tweak: increased the outdoorsman levels needed to craft poultice and bitters to match stims and super stims
tweak: lowered the OD threshold for stim fluid to prevent muh prestimming with the higher heal rates.
balance: made bitter drinks function similarly to super stims
balance: made poultice function similarly to stims
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
