### PR TITLE
Removes the skill requirement for making keys and locks

### DIFF
--- a/code/game/objects/items/stacks/sheets/sheet_types.dm
+++ b/code/game/objects/items/stacks/sheets/sheet_types.dm
@@ -31,10 +31,10 @@ GLOBAL_LIST_INIT(metal_recipes, list ( \
 	new/datum/stack_recipe("metal parts", /obj/item/stack/crafting/metalparts, 5, skill_threshold = REGULAR_CHECK), \
 	new/datum/stack_recipe("length of chain", /obj/item/blacksmith/chain, 1, time = 50), \
 	null, \
-	new/datum/stack_recipe("lock", /obj/item/lock_construct, 1, skill_threshold = EASY_CHECK), \
+	new/datum/stack_recipe("lock", /obj/item/lock_construct, 1), \
 	new/datum/stack_recipe("coffee pot", /obj/item/crafting/coffee_pot, 1), \
 	new/datum/stack_recipe("lunchbox", /obj/item/crafting/lunchbox, 1), \
-	new/datum/stack_recipe("key", /obj/item/key, 1, skill_threshold = EASY_CHECK), \
+	new/datum/stack_recipe("key", /obj/item/key, 1), \
 	new/datum/stack_recipe("key chain", /obj/item/storage/keys_set, 1), \
 	null, \
 	new/datum/stack_recipe("seed extractor", /obj/structure/legion_extractor, 6, one_per_turf = TRUE, on_floor = TRUE), \


### PR DESCRIPTION
## About The Pull Request
Exactly what it says on the tin. Keys and locks are crucial player tools for getting a private place to store stuff or do scenes, and locking it behind putting skills into Repair isn't accomplishing anything useful.

## Pre-Merge Checklist
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
<!-- Tick these after making the PR. -->

## Changelog
:cl: SingingSpock
tweak: Locks and Keys no longer require Repair skill to make
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
