### PR TITLE
Fallout13 medicine redone (bear and bull made equal version two)

### DIFF
--- a/code/datums/components/crafting/recipes/recipes_medicine.dm
+++ b/code/datums/components/crafting/recipes/recipes_medicine.dm
@@ -46,6 +46,7 @@
 	category = CAT_MEDICAL
 	skill_needed = SKILL_SCIENCE
 	skill_level = EASY_CHECK
+	falls_back_on_outdoors = TRUE
 
 /datum/crafting_recipe/upgraded_gauze
 	name = "Improved Gauze"
@@ -63,10 +64,11 @@
 	result = /obj/item/stack/medical/suture/five
 	time = 50
 	reqs = list(/obj/item/stack/medical/gauze = 1,
-				/datum/reagent/medicine/styptic_powder = 10)
+				/datum/reagent/abraxo_cleaner = 10)
 	category = CAT_MEDICAL
 	skill_needed = SKILL_SCIENCE
 	skill_level = EASY_CHECK
+	falls_back_on_outdoors = TRUE
 
 /datum/crafting_recipe/ointment
 	name = "Improvised Ointment"
@@ -111,27 +113,35 @@
 /datum/crafting_recipe/bitterdrink
 	name = "Bottle bitterdrink"
 	result = /obj/item/reagent_containers/pill/bitterdrink
-	reqs = list(/obj/item/reagent_containers/food/snacks/grown/broc = 1,
-				/obj/item/reagent_containers/food/snacks/grown/xander = 1,
-				/obj/item/reagent_containers/food/drinks/bottle = 1)
+	reqs = list(/obj/item/reagent_containers/food/snacks/grown/broc = 2,
+				/obj/item/reagent_containers/food/snacks/grown/xander = 2,
+				/obj/item/reagent_containers/food/snacks/grown/agave = 1,
+				/obj/item/reagent_containers/food/snacks/grown/fungus = 1,
+				/obj/item/stack/sheet/leather = 1,
+				/datum/reagent/consumable/nuka_cola = 25,
+				/datum/reagent/radium = 5)
 	tools = list(TOOL_ALCHEMY_TABLE)
 	time = 10
 	category = CAT_MEDICAL
 	skill_needed = SKILL_OUTDOORSMAN
-	skill_level = REGULAR_CHECK
+	skill_level = HARD_CHECK
 
 /datum/crafting_recipe/bitterdrink5
 	name = "Batch of bitterdrink (x5)"
 	result = /obj/item/storage/box/medicine/bitterdrink5
-	reqs = list(/obj/item/reagent_containers/food/snacks/grown/broc = 5,
-				/obj/item/reagent_containers/food/snacks/grown/xander = 5,
-				/obj/item/reagent_containers/food/drinks/bottle = 5)
+	reqs = list(/obj/item/reagent_containers/food/snacks/grown/broc = 10,
+				/obj/item/reagent_containers/food/snacks/grown/xander = 10,
+				/obj/item/reagent_containers/food/snacks/grown/agave = 5,
+				/obj/item/reagent_containers/food/snacks/grown/fungus = 5,
+				/obj/item/stack/sheet/leather = 5,
+				/datum/reagent/consumable/nuka_cola = 125,
+				/datum/reagent/radium = 25)
 	tools = list(TOOL_ALCHEMY_TABLE)
 	time = 20
 	category = CAT_MEDICAL
 	always_available = FALSE
 	skill_needed = SKILL_OUTDOORSMAN
-	skill_level = REGULAR_CHECK
+	skill_level = HARD_CHECK
 
 /datum/crafting_recipe/healpoultice
 	name = "Healing poultice"
@@ -144,7 +154,7 @@
 	time = 10
 	category = CAT_MEDICAL
 	skill_needed = SKILL_OUTDOORSMAN
-	skill_level = EASY_CHECK
+	skill_level = REGULAR_CHECK
 
 /datum/crafting_recipe/healpoultice5
 	name = "Batch of healing poultice (x5)"
@@ -157,7 +167,7 @@
 	time = 20
 	category = CAT_MEDICAL
 	skill_needed = SKILL_OUTDOORSMAN
-	skill_level = EASY_CHECK
+	skill_level = REGULAR_CHECK
 
 /datum/crafting_recipe/smell_salts
 	name = "Smelling salts"

--- a/code/modules/fallout/reagents/medicines.dm
+++ b/code/modules/fallout/reagents/medicines.dm
@@ -1,22 +1,22 @@
 /* 
- * Stimpak Juice
- * Initial insta-heal
+ * Generic fallout13 medicine
  * Some lingering heal over time
  * Heals either brute or burn per tick, whichever's higher
  * Overdose makes you barf stunlock yourself
  */
 /datum/reagent/medicine/stimpak	// Supplemented by other chems within a stimpak
-	name = "Stimfluid"
+	name = "Medicinal fluid"
 	description = "A cocktail of advanced medicines designed to rapidly heal wounds."
 	reagent_state = LIQUID
 	color = "#eb0000"
 	taste_description = "numbness"
-	metabolization_rate = 5 * REAGENTS_METABOLISM
-	overdose_threshold = 60
+	metabolization_rate = 1 * REAGENTS_METABOLISM
+	overdose_threshold = 30
 	value = REAGENT_VALUE_COMMON
 	ghoulfriendly = TRUE
 
 // insta-heal on inject, 1 of each brute and burn per volume
+/*
 /datum/reagent/medicine/stimpak/reaction_mob(mob/living/M, method=INJECT, reac_volume)
 	if(iscarbon(M))
 		if(M.stat == DEAD) // Doesnt work on the dead
@@ -28,13 +28,18 @@
 		if(M.getFireLoss())
 			M.adjustFireLoss(-reac_volume)
 	..()
+*/
 
-// heals 1 damage of either brute or burn on life, whichever's higher
+/datum/reagent/medicine/stimpak/on_mob_end_metabolize(mob/living/carbon/M) //Informs you that you are no longer healing
+	. = ..()
+	to_chat(M, span_notice("You feel clean of your medicine's effects."))
+
+// heals 2 damage of either brute or burn on life, whichever's higher
 /datum/reagent/medicine/stimpak/on_mob_life(mob/living/carbon/M)
 	if(M.getBruteLoss() > M.getFireLoss())	//Less effective at healing mixed damage types.
-		M.adjustBruteLoss(-1*REAGENTS_EFFECT_MULTIPLIER)
+		M.adjustBruteLoss(-2*REAGENTS_EFFECT_MULTIPLIER)
 	else
-		M.adjustFireLoss(-1*REAGENTS_EFFECT_MULTIPLIER)
+		M.adjustFireLoss(-2*REAGENTS_EFFECT_MULTIPLIER)
 	. = TRUE
 	..()
 
@@ -46,24 +51,25 @@
 	. = TRUE
 
 /* 
- * Super Stimpak Juice
+ * Generic fallout13 advanced medicine
  * Initial insta-heal
  * Fixes up cuts like a weaker sanguirite
  * Overdose makes your heart die
  */
 
 /datum/reagent/medicine/super_stimpak // Handles superior healing of the super stim cocktail, plus its wound recovery, stim sickness, and dangerous OD.
-	name = "super stimfluid"
+	name = "advanced medicinal fluid"
 	description = "Advanced, potent healing chemicals."
 	reagent_state = LIQUID
 	color = "#e50d0d"
 	taste_description = "numbness"
-	metabolization_rate = 3 * REAGENTS_METABOLISM	// 50 seconds, same as poultice
-	overdose_threshold = 40	// you can risk a second dose
+	metabolization_rate = 1 * REAGENTS_METABOLISM	// 50 seconds, same as poultice
+	overdose_threshold = 30	// you can risk a second dose
 	ghoulfriendly = TRUE
 	var/clot_rate = 0.10
 	var/clot_coeff_per_wound = 0.7
 
+/*
 /datum/reagent/medicine/super_stimpak/reaction_mob(mob/living/M, method=INJECT, reac_volume)
 	if(iscarbon(M))
 		if(M.stat == DEAD)
@@ -75,6 +81,7 @@
 		if(M.getFireLoss())
 			M.adjustFireLoss(-reac_volume)
 	..()
+*/
 
 /// Slows you down and tells you that your heart's gonna get wrecked if you keep taking more
 /datum/reagent/medicine/super_stimpak/on_mob_metabolize(mob/living/carbon/M) // Stim Sickness
@@ -88,8 +95,12 @@
 	M.remove_movespeed_modifier(/datum/movespeed_modifier/super_stimpak_slowdown)
 	to_chat(M, span_notice("Your heart slows to a more reasonable pace, and your aching muscular fatigue fades.")) // tells you when it's safe to take another dose
 
-/// Seals up bleeds like a weaker sanguirite, doesnt do any passive heals though
-/datum/reagent/medicine/super_stimpak/on_mob_life(mob/living/carbon/M) // Heals fleshwounds like a weak sanguirite
+// Heal 2 damage of brute, burn and tox on life. Seals wounds.
+/datum/reagent/medicine/super_stimpak/on_mob_life(mob/living/carbon/M)
+	. = ..()
+	M.adjustBruteLoss(-2*REAGENTS_EFFECT_MULTIPLIER)
+	M.adjustFireLoss(-2*REAGENTS_EFFECT_MULTIPLIER)
+	M.adjustToxLoss(-2*REAGENTS_EFFECT_MULTIPLIER)
 	clot_bleed_wounds(user = M, bleed_reduction_rate = clot_rate, coefficient_per_wound = clot_coeff_per_wound, single_wound_full_effect = FALSE)
 	. = TRUE
 	..()
@@ -156,15 +167,15 @@
 	reagent_state = SOLID
 	color = "#A9FBFB"
 	taste_description = "bitterness"
-	metabolization_rate = 2 * REAGENTS_METABOLISM	// same as bicaridine
+	metabolization_rate = 1 * REAGENTS_METABOLISM	// same as bicaridine
 	overdose_threshold = 30
 	ghoulfriendly = TRUE
 
 /datum/reagent/medicine/healing_powder/on_mob_life(mob/living/carbon/M)
 	if(M.getBruteLoss() > M.getFireLoss())	//Less effective at healing mixed damage types.
-		M.adjustBruteLoss(-4*REAGENTS_EFFECT_MULTIPLIER)
+		M.adjustBruteLoss(-2*REAGENTS_EFFECT_MULTIPLIER)
 	else
-		M.adjustFireLoss(-4*REAGENTS_EFFECT_MULTIPLIER)
+		M.adjustFireLoss(-2*REAGENTS_EFFECT_MULTIPLIER)
 	. = TRUE
 	..()
 
@@ -181,6 +192,7 @@
  * Ghouls love it
  */
 
+/*
 /datum/reagent/medicine/healing_powder/poultice	// Handles superior healing of the poultice herbal mix, with its superior healing, wound recovery, and painful OD
 	name = "Healing poultice"
 	description = "Potent, stinging herbs that swiftly aid in the recovery of grevious wounds."
@@ -219,6 +231,7 @@
 		to_chat(M, span_notice("[poultice_od_message]"))
 	. = TRUE
 	..()
+*/
 
 
 // ---------------------------

--- a/code/modules/reagents/reagent_containers/hypospray.dm
+++ b/code/modules/reagents/reagent_containers/hypospray.dm
@@ -152,16 +152,16 @@
 // FALLOUT HYPOS //
 ///////////////////
 
-/obj/item/reagent_containers/hypospray/medipen/stimpak // 20hp instantly, plus 30hp over 20 seconds. stims in fallout contain a whole cocktail of chems, and this mix prevents them from stacking with healing powder and bitter drink.
+/obj/item/reagent_containers/hypospray/medipen/stimpak //Heals 6 HP on life.
 	name = "stimpak"
 	desc = "A handheld delivery system for medicine, used to rapidly heal physical damage to the body."
 	icon = 'icons/fallout/objects/medicine/drugs.dmi'
 	icon_state = "hypo_stimpak"
 	custom_price = PRICE_STIMPAK
-	volume = 26
-	amount_per_transfer_from_this = 26
+	volume = 60
+	amount_per_transfer_from_this = 60
 	reagent_flags = DRAWABLE
-	list_reagents = list(/datum/reagent/medicine/stimpak = 20, /datum/reagent/medicine/healing_powder = 2, /datum/reagent/medicine/bicaridine = 2, /datum/reagent/medicine/kelotane = 2)
+	list_reagents = list(/datum/reagent/medicine/stimpak = 15, /datum/reagent/medicine/healing_powder = 15, /datum/reagent/medicine/bicaridine = 15, /datum/reagent/medicine/kelotane = 15)
 
 /obj/item/reagent_containers/hypospray/medipen/stimpak/on_reagent_change(changetype)
 	update_icon()
@@ -195,14 +195,14 @@
 // ---------------------------------
 // SUPER STIMPAK
 
-/obj/item/reagent_containers/hypospray/medipen/stimpak/super // 50hp instantly, plus 50hp over 20 seconds.
+/obj/item/reagent_containers/hypospray/medipen/stimpak/super // Heals 8 HP on life and closes wounds. Slows you down in the meantime.
 	name = "super stimpak"
 	desc = "The super version comes in a hypodermic, but with an additional vial containing more powerful drugs than the basic model and a leather belt to strap the needle to the injured limb."
 	icon_state = "hypo_superstimpak"
 	custom_price = PRICE_SUPER_STIM
-	volume = 62
-	amount_per_transfer_from_this = 62
-	list_reagents = list(/datum/reagent/medicine/super_stimpak = 30, /datum/reagent/medicine/stimpak = 20, /datum/reagent/medicine/healing_powder = 4, /datum/reagent/medicine/bicaridine = 4, /datum/reagent/medicine/kelotane = 4)
+	volume = 50
+	amount_per_transfer_from_this = 50
+	list_reagents = list(/datum/reagent/medicine/super_stimpak = 10, /datum/reagent/medicine/stimpak = 10, /datum/reagent/medicine/healing_powder = 10, /datum/reagent/medicine/bicaridine = 10, /datum/reagent/medicine/kelotane = 10)
 
 /obj/item/reagent_containers/hypospray/medipen/stimpak/super/custom
 	desc = "The super version comes in a hypodermic, but with an additional vial to inject more drugs than the basic model and a leather belt to strap the needle to a limb. This particular one will deliver a tailored cocktail."

--- a/code/modules/reagents/reagent_containers/patch.dm
+++ b/code/modules/reagents/reagent_containers/patch.dm
@@ -72,13 +72,13 @@
 // ---------------------------------
 // HEALING POWDER
 
-/obj/item/reagent_containers/pill/healingpowder // 50hp over 50 seconds.
+/obj/item/reagent_containers/pill/healingpowder // Heals 4 HP on life. Doesn't tell you when it's safe to take another dose like better medicines do.
 	name = "Healing powder"
 	desc = "A powder used to heal physical wounds derived from ground broc flowers and xander roots, commonly used by tribals."
 	icon = 'icons/fallout/objects/medicine/drugs.dmi'
 	icon_state = "patch_healingpowder"
-	list_reagents = list(/datum/reagent/medicine/healing_powder = 10)
-	self_delay = 1
+	list_reagents = list(/datum/reagent/medicine/healing_powder = 10, /datum/reagent/medicine/bicaridine = 10, /datum/reagent/medicine/kelotane = 10)
+	self_delay = 0
 
 // ---------------------------------
 // CUSTOM POWDER
@@ -89,30 +89,30 @@
 	list_reagents = null
 	icon = 'icons/fallout/objects/medicine/drugs.dmi'
 	icon_state = "patch_healingpowder"
-	self_delay = 2
+	self_delay = 0
 	color = COLOR_PALE_GREEN_GRAY
 
 // ---------------------------------
 // HEALING POULTICE
 
-/obj/item/reagent_containers/pill/patch/healpoultice // 100hp over 50 seconds. a bit more potent than just bitters.
+/obj/item/reagent_containers/pill/patch/healpoultice // Tribal stimpaks.
 	name = "Healing poultice"
 	desc = "A concoction of broc flower, cave fungus, agrave fruit and xander root."
 	icon = 'icons/fallout/objects/medicine/drugs.dmi'
-	list_reagents = list(/datum/reagent/medicine/healing_powder/poultice = 10, /datum/reagent/medicine/healing_powder = 10, /datum/reagent/medicine/bicaridine = 5, /datum/reagent/medicine/kelotane = 5)
+	list_reagents = list(/datum/reagent/medicine/stimpak = 15, /datum/reagent/medicine/healing_powder = 15, /datum/reagent/medicine/bicaridine = 15, /datum/reagent/medicine/kelotane = 15)
 	icon_state = "patch_healingpoultice"
-	self_delay = 1
+	self_delay = 0
 
 // ---------------------------------
 // BITTER DRINK
 
-/obj/item/reagent_containers/pill/bitterdrink // 50hp over 25 seconds
+/obj/item/reagent_containers/pill/bitterdrink // Tribal super stims.
 	name = "Bitter drink"
 	desc = "A strong herbal healing concoction invented and created by the Twin Mothers tribe."
 	icon = 'icons/fallout/objects/medicine/drugs.dmi'
 	icon_state = "patch_bitterdrink"
-	list_reagents = list(/datum/reagent/medicine/healing_powder = 5, /datum/reagent/medicine/bicaridine = 5, /datum/reagent/medicine/kelotane = 5) 
-	self_delay = 1
+	list_reagents = list(/datum/reagent/medicine/super_stimpak = 10, /datum/reagent/medicine/stimpak = 10, /datum/reagent/medicine/healing_powder = 10, /datum/reagent/medicine/bicaridine = 10, /datum/reagent/medicine/kelotane = 10) 
+	self_delay = 0
 
 // ---------------------------------
 // HYDRA - never a thing, make it something. Sprites done.


### PR DESCRIPTION
## About The Pull Request
Makes NCR and Legion medicine equal, with Legion medicine being a little more expensive. Poultice and stims heal the same, bitter drink and super stims heal the same. Also alters the crafting recipies for tribal medicine to require one more skill level in outdoorsman.

Medicine in general is changed as well. Instant heals are removed and the medicines' tiers are based on how quickly they heal damage instead of how much. Each medicine has reagents that metabolize at the same rate, so there's no stacking them with extra kelotane and bicardine and the rate of healing is constant instead of all over the place like it was in the past. Outdoorsman skill now also lets you craft regular gauze and suture, but not the advanced ones.

## Pre-Merge Checklist
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
<!-- Tick these after making the PR. -->

## Changelog
:cl:
del: Commented out the poultice reagent.
add: Message sent to the player when stim fluid is done metabolizing.
tweak: Renamed stimfluid and superstimfluid to medicinal fluid and advanced medicinal fluid.
tweak: Edited the values of fallout13's healing fluids to focus more on health over time and metabolize like base ss13 chems.
tweak: Fallout13 meds no longer instaheal and metabolize/od at the same rate as bicaridine and kelotane.
tweak: Tribal and regular medicine have equal reagents in equal amounts for each tier.
tweak: Tribal medicine recipes made harder by needing a higher outdoorsman skill level and more ingredients.
tweak: Regular suture and gauze recipes fall back on outdoorsman.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
