### PR TITLE
Radio Jammer Removal

### DIFF
--- a/_maps/map_files/Blythe-small/blythe-lower.dmm
+++ b/_maps/map_files/Blythe-small/blythe-lower.dmm
@@ -3251,7 +3251,6 @@
 /area/f13/brotherhood/rnd)
 "cwB" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/item/jammer,
 /obj/structure/table,
 /turf/open/floor/plating/rust,
 /area/f13/tunnel)
@@ -18222,7 +18221,6 @@
 "opy" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/table/wood,
-/obj/item/jammer,
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/bunker/bunkernine)
 "opM" = (


### PR DESCRIPTION
## About The Pull Request
The following PR removes the radio jammer from spawning on Blythe. The map has insane issues as is and offers no counterplay to your deployment of this device so with that said, it's being removed.

## Pre-Merge Checklist
- [ ] You tested this on a local server.
- [ ] This code did not runtime during testing.
- [ ] You documented all of your changes.
<!-- Tick these after making the PR. -->

## Changelog
:cl:
add: remove radio jammer
/:cl: