### PR TITLE
Roundstart Removal of Stormdrum

### DIFF
--- a/code/modules/jobs/job_types/wasteland.dm
+++ b/code/modules/jobs/job_types/wasteland.dm
@@ -1757,7 +1757,7 @@ datum/job/wasteland/f13dendoctor
 	/datum/outfit/loadout/wayfarershaman,
 	/datum/outfit/loadout/shaman,
 	/datum/outfit/loadout/lostvillager,
-	/datum/outfit/loadout/whitelegsranged,
+	/datum/outfit/loadout/whitelegsmelee,
 	/datum/outfit/loadout/whitelegsshaman,
 	/datum/outfit/loadout/eightiesmelee,
 	/datum/outfit/loadout/eightiesranged,
@@ -1896,16 +1896,14 @@ datum/job/wasteland/f13dendoctor
 		/obj/item/book/granter/trait/tribaltraditions =1,
 		)
 
-/datum/outfit/loadout/whitelegsranged
-	name = "White Legs Storm-Drummer"
+/datum/outfit/loadout/whitelegsmelee
+	name = "White Leg Warrior"
 	suit = /obj/item/clothing/suit/armor/medium/tribal/whitelegs
 	backpack_contents = list(
 		/obj/item/clothing/under/f13/whitelegs = 1,
 		/obj/item/clothing/under/f13/female/whitelegs = 1,
-		/obj/item/gun/ballistic/automatic/smg/tommygun/whitelegs = 1,
-		///obj/item/gun/ballistic/automatic/pistol/ninemil = 1,
 		/obj/item/reagent_containers/pill/patch/healpoultice = 1,
-		///obj/item/ammo_box/magazine/tommygunm45/stick = 2
+		/obj/item/twohanded/spear/bonespear = 1,
 	)
 
 /datum/outfit/loadout/whitelegsshaman


### PR DESCRIPTION
## About The Pull Request
The stormdrum was simply too good to be at round start -- automatics should be rare, not something earned at round start. Additional PRs will happen.

## Pre-Merge Checklist
- [ ] You tested this on a local server.
- [ ] This code did not runtime during testing.
- [ ] You documented all of your changes.
<!-- Tick these after making the PR. -->

## Changelog
:cl:
del: removes the round start automatic.
/:cl: