### PR TITLE
NCR Badge and Spawns Fix

### DIFF
--- a/_maps/map_files/Blythe-small/blythe-surface.dmm
+++ b/_maps/map_files/Blythe-small/blythe-surface.dmm
@@ -245,6 +245,10 @@
 	icon_state = "bluedirtychess2"
 	},
 /area/f13/ambientlighting/building/c)
+"afT" = (
+/obj/effect/landmark/start/f13/ncrveteranranger,
+/turf/open/floor/wood_common,
+/area/f13/ncr)
 "afZ" = (
 /obj/structure/table/wood,
 /obj/item/melee/onehanded/knife/bone,
@@ -11790,6 +11794,10 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel/khanfort)
+"fLF" = (
+/obj/effect/landmark/start/f13/ncrranger,
+/turf/open/floor/wood_common,
+/area/f13/ncr)
 "fLQ" = (
 /obj/structure/chair/sofa/right{
 	dir = 4
@@ -16754,6 +16762,14 @@
 /obj/structure/sign/legion/latrine,
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/legion)
+"idz" = (
+/obj/effect/overlay/desert/sonora/edge,
+/obj/effect/overlay/desert/sonora/edge{
+	dir = 1
+	},
+/obj/effect/landmark/start/f13/venator,
+/turf/open/indestructible/ground/outside/gravel,
+/area/f13/wasteland/legion)
 "idD" = (
 /obj/structure/chair/bench{
 	dir = 1;
@@ -20831,6 +20847,12 @@
 /obj/effect/spawner/lootdrop/trash,
 /turf/open/floor/wood_common,
 /area/f13/ambientlighting/building/t)
+"jWU" = (
+/obj/effect/landmark/start/f13/ncrspecialist,
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "verticalinnermain1"
+	},
+/area/f13/wasteland/ncr)
 "jXm" = (
 /obj/structure/destructible/tribal_torch/wall/lit{
 	dir = 1;
@@ -26628,6 +26650,10 @@
 	icon_state = "floorrusty"
 	},
 /area/f13/ambientlighting/building/l)
+"mGq" = (
+/obj/effect/landmark/start/f13/ncrcivilianranger,
+/turf/open/floor/wood_common,
+/area/f13/ncr)
 "mGt" = (
 /obj/structure/flora/grass/wasteland{
 	icon_state = "tall_grass_2"
@@ -32925,6 +32951,12 @@
 /obj/structure/closet/crate/bin,
 /turf/open/floor/plasteel/f13/stone,
 /area/f13/ncr)
+"pFL" = (
+/obj/effect/landmark/start/f13/ncrspecialist,
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "horizontalinnermainright"
+	},
+/area/f13/wasteland/ncr)
 "pFP" = (
 /obj/structure/simple_door/metal/fence{
 	dir = 4
@@ -45932,6 +45964,12 @@
 	icon_state = "verticalinnermain0"
 	},
 /area/f13/wasteland/city)
+"vWi" = (
+/obj/effect/landmark/start/f13/ncrspecialist,
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "verticalinnermain2"
+	},
+/area/f13/wasteland/ncr)
 "vWD" = (
 /obj/effect/spawner/lootdrop/trash,
 /turf/open/indestructible/ground/outside/desert{
@@ -54576,7 +54614,7 @@ uQE
 uQE
 oIH
 oIH
-oIH
+vWi
 oIH
 oIH
 oIH
@@ -54778,7 +54816,7 @@ qUy
 uQE
 uQE
 uQE
-uQE
+jWU
 uQE
 uQE
 uQE
@@ -55182,7 +55220,7 @@ uQE
 uQE
 uQE
 uQE
-uQE
+jWU
 uQE
 uQE
 oIH
@@ -55586,7 +55624,7 @@ uQE
 mjk
 fNL
 fNL
-fNL
+pFL
 bbF
 kmN
 kmN
@@ -56420,8 +56458,8 @@ lsP
 vXq
 vXq
 vXq
-vXq
-vXq
+mGq
+fLF
 vXq
 lsP
 uLX
@@ -56622,8 +56660,8 @@ lsP
 xsW
 eNS
 vXq
-vXq
-vXq
+mGq
+afT
 vXq
 lsP
 lsP
@@ -93305,7 +93343,7 @@ hne
 scy
 scy
 hne
-raF
+idz
 hne
 hne
 rrr

--- a/code/modules/jobs/job_types/ncr.dm
+++ b/code/modules/jobs/job_types/ncr.dm
@@ -643,6 +643,7 @@ Weapons		Service Rifle, Grease Gun, 9mm pistol, all good.
 
 /datum/outfit/job/ncr/f13ranger
 	name = "NCR Ranger"
+	jobtype	= /datum/job/ncr/f13ranger
 	id = /obj/item/card/id/dogtag/ncrranger
 	uniform	= /obj/item/clothing/under/f13/ranger/trail
 	suit = /obj/item/clothing/suit/armor/light/ncr/trailranger

--- a/code/modules/jobs/job_types/ncr.dm
+++ b/code/modules/jobs/job_types/ncr.dm
@@ -618,6 +618,7 @@ Weapons		Service Rifle, Grease Gun, 9mm pistol, all good.
 	spawn_positions = 3
 	description = "As an NCR Ranger, you are the premier special forces unit of the NCR. You are the forward observations and support the Army in it's campaigns, as well as continuing the tradition of stopping slavery in it's tracks."
 	supervisors = "Veteran Ranger"
+	access = list(ACCESS_NCR, ACCESS_NCR_ARMORY)
 	selection_color = "#fff5cc"
 	display_order = JOB_DISPLAY_ORDER_RANGER
 	outfit = /datum/outfit/job/ncr/f13ranger
@@ -705,6 +706,7 @@ Weapons		Service Rifle, Grease Gun, 9mm pistol, all good.
 	spawn_positions = 2
 	description = "As an NCR Civilian Ranger, you are a low-ranking member of the premier special forces of the NCR. You are to aid the Rangers and Veteran Ranger in scouting operations and acting as support for Ranger activites."
 	supervisors = "Rangers and the Veteran Ranger"
+	access = list(ACCESS_NCR, ACCESS_NCR_ARMORY)
 	selection_color = "#fff5cc"
 	display_order = JOB_DISPLAY_ORDER_CIVILIANRANGER
 	outfit = /datum/outfit/job/ncr/f13civilianranger

--- a/code/modules/jobs/job_types/ncr.dm
+++ b/code/modules/jobs/job_types/ncr.dm
@@ -643,11 +643,11 @@ Weapons		Service Rifle, Grease Gun, 9mm pistol, all good.
 
 /datum/outfit/job/ncr/f13ranger
 	name = "NCR Ranger"
-	jobtype	= /datum/job/ncr/f13ranger
 	id = /obj/item/card/id/dogtag/ncrranger
-	uniform	= /datum/gear/uniform/ranger/patrol
-	head = /obj/item/clothing/head/f13/ncr/patrol
-	gloves = /obj/item/clothing/gloves/patrol
+	uniform	= /obj/item/clothing/under/f13/ranger/trail
+	suit = /obj/item/clothing/suit/armor/light/ncr/trailranger
+	head = /obj/item/clothing/head/f13/ncr/ranger
+	gloves = /obj/item/clothing/gloves/rifleman
 	shoes = /obj/item/clothing/shoes/f13/military/leather
 	glasses	= /obj/item/clothing/glasses/sunglasses
 	ears = /obj/item/radio/headset/headset_ranger


### PR DESCRIPTION
## About The Pull Request
This PR fixes the armor and clothing datums for the regular ranger spawn. Jobtype had to be reset; I fixed that. This PR also adds spawns.

## Pre-Merge Checklist
- [ ] You tested this on a local server.
- [ ] This code did not runtime during testing.
- [ ] You documented all of your changes.
<!-- Tick these after making the PR. -->

## Changelog
🆑 
fix: ncr ranger fix
add: additional landmarks for legion
/:cl: