### PR TITLE
Renames Legion Off-Duty to Camp-Duty

### DIFF
--- a/code/modules/jobs/job_types/legion.dm
+++ b/code/modules/jobs/job_types/legion.dm
@@ -978,18 +978,18 @@ Weapons		Lever shotgun, Grease gun, Repeater carbines, Revolvers, simple guns al
 // Immunes are mostly an off-duty role meant to attend to the camp itself and the slaves or prisoners within.
 
 /datum/job/CaesarsLegion/Legionnaire/f13immune
-	title = "Legion Off-Duty"
+	title = "Legion Camp-Duty"
 	flag = F13IMMUNE
 	total_positions = 4
 	spawn_positions = 4
-	description = "An Immune is a legionnaire temporarily assigned to keeping the camp in order, according to their tasking on any given week."
-	supervisors = "the Centurion."
+	description = "You answer to any member of the Legion that is currently on-duty, but take orders directly from the Auxilia around the camp. Your diligence in serving Caesar as one of his Legionaries has earnt you a break; light camp duty. You may perform any tasks required of you, for you know how to serve the Legion well, but remember to rest, your time on the battlefield will return shortly."
+	supervisors = "the Centurion, the Auxilia."
 	display_order = JOB_DISPLAY_ORDER_IMMUNE
 	outfit = /datum/outfit/job/CaesarsLegion/Legionnaire/f13immune
 	exp_requirements = 150
 
 /datum/outfit/job/CaesarsLegion/Legionnaire/f13immune
-	name = "Legion Off-Duty"
+	name = "Legion Camp-Duty"
 	jobtype = /datum/job/CaesarsLegion/Legionnaire/f13immune
 	id = /obj/item/card/id/dogtag/legimmune
 	mask = /obj/item/clothing/mask/bandana/legion/camp


### PR DESCRIPTION
## About The Pull Request
Renames Off-Duty Legionare to Camp-Duty Legionare.
This is a slave army, rest and relaxation would exist in the form of light camp work, not leave. Hopefully this satisfies both the people with a stick up their ass about lore and anyone who actually uses this role.

## Pre-Merge Checklist
- [ ] You tested this on a local server.
- [ ] This code did not runtime during testing.
- [ ] You documented all of your changes.
<!-- Tick these after making the PR. -->

## Changelog
:cl:
add: Added new things
add: Added more things
del: Removed old things
tweak: tweaked a few things
balance: rebalanced something
fix: fixed a few things
soundadd: added a new sound thingy
sounddel: removed an old sound thingy
imageadd: added some icons and images
imagedel: deleted some icons and images
spellcheck: fixed a few typos
code: changed some code
refactor: refactored some code
config: changed some config setting
admin: messed with admin stuff
server: something server ops should know
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
