### PR TITLE
Hobo Weapon Removal

### DIFF
--- a/_maps/RandomZLevels/VR/yuma_VR.dmm
+++ b/_maps/RandomZLevels/VR/yuma_VR.dmm
@@ -2277,7 +2277,6 @@
 /obj/item/gun/ballistic/automatic/assault_rifle,
 /obj/item/gun/ballistic/automatic/assault_rifle/infiltrator,
 /obj/item/gun/ballistic/automatic/autopipe,
-/obj/item/gun/ballistic/automatic/hobo/destroyer,
 /obj/item/gun/ballistic/automatic/m1carbine,
 /obj/item/gun/ballistic/automatic/m1carbine/compact,
 /obj/item/gun/ballistic/automatic/m1garand,

--- a/code/__DEFINES/ammo.dm
+++ b/code/__DEFINES/ammo.dm
@@ -24,7 +24,6 @@
 #define CALIBER_MAGNETIC_HYPER "hypermagnetic rounds"
 #define CALIBER_MUSKET_BALL "musket balls"
 #define CALIBER_MUSKET_LASER "laser musket packs"
-#define CALIBER_MUSKET_PLASMA "plasma musket packs"
 #define CALIBER_NEEDLE "needles"
 #define CALIBER_ROCKET "rockets"
 #define CALIBER_SPEAR "speargun rounds"

--- a/code/datums/components/crafting/recipes/recipes_weapon_and_ammo.dm
+++ b/code/datums/components/crafting/recipes/recipes_weapon_and_ammo.dm
@@ -151,18 +151,6 @@
 	subcategory = CAT_AMMO
 	skill_level = HARD_CHECK
 
-/datum/crafting_recipe/batteryboxplasma //plasmamusket ammo
-	name = "Plasma Can"
-	result = /obj/item/ammo_box/plasmamusket
-	reqs = list(/obj/item/stack/crafting/electronicparts = 2,
-				/obj/item/stack/sheet/glass = 3,
-				/obj/item/stack/sheet/metal = 3)
-	tools = list(TOOL_WORKBENCH, TOOL_MULTITOOL)
-	time = 20
-	category = CAT_WEAPONRY
-	subcategory = CAT_AMMO
-	skill_level = HARD_CHECK
-
 /datum/crafting_recipe/batterybox //lasmusket ammo
 	name = "Laser Musket battery pack"
 	result = /obj/item/ammo_box/lasmusket
@@ -572,18 +560,6 @@
 	time = 120
 	category = CAT_WEAPONRY
 	subcategory = CAT_WEAPON
-
-/datum/crafting_recipe/gun/plasmamusket
-	name = "Plasma musket"
-	result = /obj/item/gun/ballistic/rifle/hobo/plasmacaster
-	reqs = list(/obj/item/gun/ballistic/rifle/hobo/lasmusket = 1,
-				/obj/item/stack/crafting/electronicparts = 2,
-				/obj/item/advanced_crafting_components/conductors = 1)
-	tools = list(TOOL_WORKBENCH, TOOL_MULTITOOL)
-	time = 120
-	category = CAT_WEAPONRY
-	subcategory = CAT_WEAPON
-	skill_level = HARD_CHECK
 
 /datum/crafting_recipe/gun/lasmusket
 	name = "Laser musket"

--- a/code/game/objects/effects/spawners/themed_loot_tables.dm
+++ b/code/game/objects/effects/spawners/themed_loot_tables.dm
@@ -204,7 +204,6 @@
 		/obj/item/gun/ballistic/revolver/hobo/knifegun = 4,
 		/obj/item/gun/ballistic/revolver/hobo/knucklegun = 3,
 		/obj/effect/spawner/bundle/f13/guns/tommygun = 2,
-		/obj/item/gun/ballistic/automatic/hobo/destroyer = 1,
 		/obj/item/gun/ballistic/revolver/russian = 1,
 		/obj/item/twohanded/baseball/spiked = 8,
 		/obj/item/melee/unarmed/brass/spiked = 5,

--- a/code/modules/clothing/head/f13_helmets.dm
+++ b/code/modules/clothing/head/f13_helmets.dm
@@ -341,7 +341,7 @@
 	flags_inv = HIDEEARS|HIDEHAIR
 
 /obj/item/clothing/head/helmet/f13/legion/venator
-	name = "legion explorer hood"
+	name = "legion venator hood"
 	desc = "A leather hood with a sturdy metal skullcap and a gold bull insignia in the front."
 	icon_state = "legion-venator"
 	item_state = "legion-venator"

--- a/code/modules/mob/living/simple_animal/hostile/retaliate/follwer.dm
+++ b/code/modules/mob/living/simple_animal/hostile/retaliate/follwer.dm
@@ -290,7 +290,7 @@
 	casingtype = /obj/item/ammo_casing/c9mm
 	projectiletype = /obj/item/projectile/bullet/c9mm/improvised
 	projectilesound = 'sound/weapons/gunshot_smg.ogg'
-	loot = list(/obj/item/gun/ballistic/automatic/hobo/destroyer)
+	loot = list(/obj/item/gun/ballistic/automatic/smg/mini_uzi)
 
 /mob/living/simple_animal/hostile/retaliate/talker/follower/faction
 	var/myplace = null

--- a/code/modules/mob/living/simple_animal/hostile/retaliate/quest_giver.dm
+++ b/code/modules/mob/living/simple_animal/hostile/retaliate/quest_giver.dm
@@ -76,7 +76,7 @@
 	casingtype = /obj/item/ammo_casing/c9mm
 	projectiletype = /obj/item/projectile/bullet/c9mm/improvised
 	projectilesound = 'sound/weapons/gunshot_smg.ogg'
-	loot = list(/obj/item/gun/ballistic/automatic/hobo/destroyer)
+	loot = list(/obj/item/gun/ballistic/automatic/smg/mini_uzi)
 	generate_find_item = TRUE
 	generate_kill_person = TRUE
 	generate_kill_animal = TRUE

--- a/code/modules/projectiles/ammunition/caseless/_caseless.dm
+++ b/code/modules/projectiles/ammunition/caseless/_caseless.dm
@@ -38,11 +38,3 @@
 	icon_state = "lasmusketbat"
 	projectile_type = /obj/item/projectile/beam/laser/musket
 	firing_effect_type = /obj/effect/temp_visual/dir_setting/firing_effect/energy
-
-/obj/item/ammo_casing/caseless/plasmacaster
-	name = "Plasma can"
-	desc = "A single use can of plasma for the plasma musket."
-	caliber = CALIBER_MUSKET_PLASMA
-	icon_state = "plasmacan"
-	projectile_type = /obj/item/projectile/f13plasma/plasmacaster
-	firing_effect_type = /obj/effect/temp_visual/dir_setting/firing_effect/energy

--- a/code/modules/projectiles/boxes_magazines/ammo_boxes.dm
+++ b/code/modules/projectiles/boxes_magazines/ammo_boxes.dm
@@ -520,17 +520,6 @@
 	custom_materials = list(/datum/material/iron = MATS_RIFLE_SMALL_BOX)
 	w_class = WEIGHT_CLASS_SMALL
 
-/obj/item/ammo_box/plasmamusket
-	name = "Canister box (Plasma musket)"
-	icon = 'icons/fallout/objects/guns/ammo.dmi'
-	icon_state = "plasmusketbox"
-	multiple_sprites = 2
-	ammo_type = /obj/item/ammo_casing/caseless/plasmacaster
-	max_ammo = 6
-	caliber = list(CALIBER_MUSKET_PLASMA)
-	custom_materials = list(/datum/material/iron = MATS_RIFLE_SMALL_BOX)
-	w_class = WEIGHT_CLASS_SMALL
-
 /obj/item/ammo_box/a40mm
 	name = "ammo box (40mm grenades)"
 	caliber = "40mm"

--- a/code/modules/projectiles/boxes_magazines/internal/shotgun.dm
+++ b/code/modules/projectiles/boxes_magazines/internal/shotgun.dm
@@ -104,11 +104,3 @@
 	caliber = list(CALIBER_MUSKET_LASER)
 	max_ammo = 6
 	multiload = 1
-
-/obj/item/ammo_box/magazine/internal/plasmacaster
-	name = "plasmacaster magazine"
-	desc = "Oh god, this shouldn't be here"
-	ammo_type = /obj/item/ammo_casing/caseless/plasmacaster
-	caliber = list(CALIBER_MUSKET_PLASMA)
-	max_ammo = 2
-	multiload = 1

--- a/code/modules/projectiles/guns/hoboguns.dm
+++ b/code/modules/projectiles/guns/hoboguns.dm
@@ -392,7 +392,7 @@
 
 	slowdown = GUN_SLOWDOWN_RIFLE_LIGHT_SEMI
 	force = GUN_MELEE_FORCE_RIFLE_HEAVY
-	weapon_weight = GUN_ONE_HAND_AKIMBO
+	weapon_weight = GUN_TWO_HAND_ONLY
 	draw_time = GUN_DRAW_QUICK
 	fire_delay = GUN_FIRE_DELAY_NORMAL
 	autofire_shot_delay = GUN_AUTOFIRE_DELAY_SLOW
@@ -414,10 +414,9 @@
 
 
 
-/////////////////////
-//PREMIUM HOBO GUNS//
-/////////////////////
-
+////////////////////
+//PREMIUM HOBO GUN//
+////////////////////
 
 //Laser musket
 /obj/item/gun/ballistic/rifle/hobo/lasmusket
@@ -447,68 +446,6 @@
 	)
 	misfire_possibilities = list(
 		GUN_MISFIRE_HURTS_USER(2, 5, 10, FIRELOSS | TOXLOSS | RADIATIONLOSS | EMPLOSS)
-	)
-
-
-//Plasma musket.
-/obj/item/gun/ballistic/rifle/hobo/plasmacaster
-	name = "Plasma Musket"
-	desc = "The cooling looks dubious and is that a empty can of beans used as a safety valve? Pray the plasma goes towards the enemy and not your face when you pull the trigger."
-	icon_state = "plasmamusket"
-	item_state = "plasmamusket"
-	mag_type = /obj/item/ammo_box/magazine/internal/plasmacaster
-	fire_delay = 20
-	var/bolt_open = FALSE
-	dryfire_sound = 'sound/f13weapons/noammoenergy.ogg'
-	dryfire_text = "*power failure*"
-	scope_state = "scope_medium"
-	scope_x_offset = 9
-	scope_y_offset = 20
-	fire_sound = 'sound/f13weapons/lasmusket_fire.ogg'
-	pump_sound = 'sound/f13weapons/lasmusket_crank.ogg'
-	equipsound = 'sound/f13weapons/equipsounds/aep7equip.ogg'
-	init_firemodes = list(
-		/datum/firemode/semi_auto
-	)
-	misfire_possibilities = list(
-		GUN_MISFIRE_HURTS_USER(1, 30, 35, FIRELOSS | TOXLOSS | RADIATIONLOSS | EMPLOSS)
-	)
-
-/* * * * * * * * * * *
- * Destroyer Carbine
- * Hobo semi-auto
- * 9mm
- * Awful accuracy
- * Common
- * * * * * * * * * * */
-
-/obj/item/gun/ballistic/automatic/hobo/destroyer
-	name = "destroyer carbine"
-	desc = "There are many ways to describe this, very few of them nice. This is a .45ACP silenced bolt action rifle - that via the expertise of a gun runner mainlining 50 liters of psycho, mentats, and turbo - has been converted into a semi auto."
-	icon_state = "destroyer-carbine"
-	item_state = "varmintrifle"
-	mag_type = /obj/item/ammo_box/magazine/greasegun
-
-	slowdown = GUN_SLOWDOWN_RIFLE_LIGHT_AUTO
-	force = GUN_MELEE_FORCE_RIFLE_HEAVY
-	weapon_weight = GUN_ONE_HAND_ONLY
-	draw_time = GUN_DRAW_QUICK
-	fire_delay = GUN_FIRE_DELAY_NORMAL
-	autofire_shot_delay = GUN_AUTOFIRE_DELAY_SLOW
-	burst_shot_delay = GUN_BURSTFIRE_DELAY_SLOWER
-	burst_size = 1
-	damage_multiplier = GUN_EXTRA_DAMAGE_T1
-	cock_delay = GUN_COCK_RIFLE_BASE
-
-	automatic_burst_overlay = TRUE
-	can_scope = FALSE
-	scope_state = "scope_medium"
-	scope_x_offset = 6
-	scope_y_offset = 14
-	semi_auto = FALSE
-	init_recoil = CARBINE_RECOIL(2.3)
-	init_firemodes = list(
-		/datum/firemode/semi_auto
 	)
 
 

--- a/code/modules/projectiles/projectile/beams.dm
+++ b/code/modules/projectiles/projectile/beams.dm
@@ -775,11 +775,6 @@
 	impact_type = /obj/effect/projectile/impact/heavy_laser
 	hitscan = TRUE
 
-/obj/item/projectile/beam/laser/musket //musket
-	name = "laser bolt"
-	damage = 40
-	armour_penetration = 0.6
-
 
 
 // BETA // Obsolete

--- a/code/modules/projectiles/projectile/beams.dm
+++ b/code/modules/projectiles/projectile/beams.dm
@@ -291,9 +291,9 @@
 //musket
 /obj/item/projectile/beam/laser/musket //musket
 	name = "laser beam"
-	damage = 45
+	damage = 34
 	hitscan = TRUE
-	armour_penetration = 0.5 //rare laser to have AP, to offset single-fire
+	armour_penetration = 0.01 //rare laser to have AP, to offset single-fire
 	pixels_per_second = TILES_TO_PIXELS(50)
 
 //plasma caster


### PR DESCRIPTION
## About The Pull Request
Removed the automatic piperifle being akimboed, removed the plasma musket because it was non-canon and OP, nerfed the shit out of the laser musket because why was it objectively better than an AER-9, and removed the destroyer carbine because it's just bad.

Also fixes ventor hood name because I was too lazy to do a separate PR.

## Pre-Merge Checklist
- [ X ] You tested this on a local server.
- [ X ] This code did not runtime during testing.
- [ X ] You documented all of your changes.
<!-- Tick these after making the PR. -->

## Changelog
:cl:
removes: Piperifle being able to be akimboed
removes: Plasma musket
balance: Rebalances laser musket
removes: Destroyer carbine; it's bad anyway.
fix: Fixes venator hood's name.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
