### PR TITLE
Removes abusive tech from Engineering and Medical techfabs

### DIFF
--- a/code/modules/research/designs/machine_desings/machine_designs_medical.dm
+++ b/code/modules/research/designs/machine_desings/machine_designs_medical.dm
@@ -95,14 +95,14 @@
 	desc = "Allows for the construction of circuit boards used to build a new Cloning Machine console."
 	id = "clonecontrol"
 	build_path = /obj/item/circuitboard/computer/cloning
-	departmental_flags = DEPARTMENTAL_FLAG_MEDICAL | DEPARTMENTAL_FLAG_ENGINEERING
+	departmental_flags = DEPARTMENTAL_FLAG_SCIENCE
 	category = list("Medical Machinery")
 
 /datum/design/board/clonepod
 	name = "Machine Design (Clone Pod)"
 	desc = "Allows for the construction of circuit boards used to build a Cloning Pod."
 	id = "clonepod"
-	departmental_flags = DEPARTMENTAL_FLAG_MEDICAL | DEPARTMENTAL_FLAG_ENGINEERING
+	departmental_flags = DEPARTMENTAL_FLAG_SCIENCE
 	build_path = /obj/item/circuitboard/machine/clonepod
 	category = list("Medical Machinery")
 
@@ -110,7 +110,7 @@
 	name = "Machine Design (Cloning Scanner)"
 	desc = "Allows for the construction of circuit boards used to build a Cloning Scanner."
 	id = "clonescanner"
-	departmental_flags = DEPARTMENTAL_FLAG_MEDICAL | DEPARTMENTAL_FLAG_ENGINEERING
+	departmental_flags = DEPARTMENTAL_FLAG_SCIENCE
 	build_path = /obj/item/circuitboard/machine/clonescanner
 	category = list("Medical Machinery")
 

--- a/code/modules/research/designs/medical_designs.dm
+++ b/code/modules/research/designs/medical_designs.dm
@@ -121,7 +121,7 @@
 	build_path = /obj/item/gun/syringe/dart
 	category = list("Medical Designs")
 	departmental_flags = DEPARTMENTAL_FLAG_MEDICAL
-*/
+
 /datum/design/plasmarefiller
 	name = "Plasma-Man Jumpsuit Refill"
 	desc = "A refill pack for the auto-extinguisher on Plasma-man suits."
@@ -131,7 +131,7 @@
 	build_path = /obj/item/extinguisher_refill
 	category = list("Medical Designs")
 	departmental_flags = DEPARTMENTAL_FLAG_ALL
-
+*/
 /datum/design/crewpinpointer
 	name = "Crew Pinpointer"
 	desc = "Allows tracking of someone's location if their suit sensors are turned to tracking beacon."
@@ -217,10 +217,10 @@
 	desc = "A plastic pressure bag for IV administration of drugs."
 	id = "chem_pack"
 	build_type = PROTOLATHE
-	departmental_flags = DEPARTMENTAL_FLAG_MEDICAL
 	materials = list(/datum/material/plastic = 1500)
 	build_path = /obj/item/reagent_containers/chem_pack
-	category = list("Medical Designs")
+	category = list("Medical Designs")	
+	departmental_flags = DEPARTMENTAL_FLAG_MEDICAL
 
 /datum/design/cloning_disk
 	name = "Cloning Data Disk"
@@ -230,7 +230,7 @@
 	materials = list(/datum/material/iron = 300, /datum/material/glass = 100, /datum/material/silver=50)
 	build_path = /obj/item/disk/data
 	category = list("Medical Designs")
-	departmental_flags = DEPARTMENTAL_FLAG_MEDICAL | DEPARTMENTAL_FLAG_SCIENCE
+	departmental_flags = DEPARTMENTAL_FLAG_SCIENCE
 
 /datum/design/organbox
 	name = "Empty Organ Box"
@@ -488,7 +488,7 @@
 	materials = list(/datum/material/iron = 600, /datum/material/glass = 600, /datum/material/silver = 600, /datum/material/gold = 600, /datum/material/plasma = 1000, /datum/material/uranium = 1000, /datum/material/diamond = 1000, /datum/material/bluespace = 1000)
 	build_path = /obj/item/organ/eyes/robotic/xray
 	category = list("Misc", "Medical Designs")
-	departmental_flags = DEPARTMENTAL_FLAG_MEDICAL
+	departmental_flags = DEPARTMENTAL_FLAG_SCIENCE
 
 /datum/design/cyberimp_thermals
 	name = "Thermal Eyes"
@@ -499,7 +499,7 @@
 	materials = list(/datum/material/iron = 600, /datum/material/glass = 600, /datum/material/silver = 600, /datum/material/gold = 600, /datum/material/plasma = 1000, /datum/material/diamond = 2000)
 	build_path = /obj/item/organ/eyes/robotic/thermals
 	category = list("Misc", "Medical Designs")
-	departmental_flags = DEPARTMENTAL_FLAG_MEDICAL
+	departmental_flags = DEPARTMENTAL_FLAG_SCIENCE
 
 /datum/design/cyberimp_antidrop
 	name = "Anti-Drop Implant"
@@ -510,7 +510,7 @@
 	materials = list(/datum/material/iron = 600, /datum/material/glass = 600, /datum/material/silver = 400, /datum/material/gold = 400)
 	build_path = /obj/item/organ/cyberimp/brain/anti_drop
 	category = list("Misc", "Medical Designs")
-	departmental_flags = DEPARTMENTAL_FLAG_MEDICAL
+	departmental_flags = DEPARTMENTAL_FLAG_SCIENCE
 
 /datum/design/cyberimp_antistun
 	name = "CNS Rebooter Implant"
@@ -967,7 +967,7 @@
 	construction_time = 15
 	build_path = /obj/machinery/plumbing/acclimator
 	category = list("Misc","Medical Designs")
-	departmental_flags = DEPARTMENTAL_FLAG_MEDICAL | DEPARTMENTAL_FLAG_SCIENCE
+	departmental_flags = DEPARTMENTAL_FLAG_SCIENCE
 
 /datum/design/disposer
 	name = "Plumbing Disposer"
@@ -978,7 +978,7 @@
 	construction_time = 15
 	build_path = /obj/machinery/plumbing/disposer
 	category = list("Misc","Medical Designs")
-	departmental_flags = DEPARTMENTAL_FLAG_MEDICAL | DEPARTMENTAL_FLAG_SCIENCE
+	departmental_flags = DEPARTMENTAL_FLAG_SCIENCE
 
 /datum/design/plumb_filter
 	name = "Plumbing Filter"
@@ -989,7 +989,7 @@
 	construction_time = 15
 	build_path = /obj/machinery/plumbing/filter
 	category = list("Misc","Medical Designs")
-	departmental_flags = DEPARTMENTAL_FLAG_MEDICAL | DEPARTMENTAL_FLAG_SCIENCE
+	departmental_flags = DEPARTMENTAL_FLAG_SCIENCE
 
 /datum/design/plumb_synth
 	name = "Plumbing Synthesizer"
@@ -1000,7 +1000,7 @@
 	construction_time = 15
 	build_path = /obj/machinery/plumbing/synthesizer
 	category = list("Misc","Medical Designs")
-	departmental_flags = DEPARTMENTAL_FLAG_MEDICAL | DEPARTMENTAL_FLAG_SCIENCE
+	departmental_flags = DEPARTMENTAL_FLAG_SCIENCE
 
 /datum/design/plumb_grinder
 	name = "Plumbing-Linked Autogrinder"
@@ -1011,7 +1011,7 @@
 	construction_time = 15
 	build_path = /obj/machinery/plumbing/grinder_chemical
 	category = list("Misc","Medical Designs")
-	departmental_flags = DEPARTMENTAL_FLAG_MEDICAL | DEPARTMENTAL_FLAG_SCIENCE
+	departmental_flags = DEPARTMENTAL_FLAG_SCIENCE
 
 /datum/design/reaction_chamber
 	name = "Plumbing Reaction Chamber"
@@ -1022,7 +1022,7 @@
 	construction_time = 15
 	build_path = /obj/machinery/plumbing/reaction_chamber
 	category = list("Misc","Medical Designs")
-	departmental_flags = DEPARTMENTAL_FLAG_MEDICAL | DEPARTMENTAL_FLAG_SCIENCE
+	departmental_flags = DEPARTMENTAL_FLAG_SCIENCE
 
 /datum/design/duct_print
 	name = "Plumbing Ducts"
@@ -1033,7 +1033,7 @@
 	construction_time = 1
 	build_path = /obj/item/stack/ducts
 	category = list("Misc","Medical Designs")
-	departmental_flags = DEPARTMENTAL_FLAG_MEDICAL | DEPARTMENTAL_FLAG_SCIENCE
+	departmental_flags = DEPARTMENTAL_FLAG_SCIENCE
 
 /datum/design/plumb_splitter
 	name = "Plumbing Chemical Splitter"
@@ -1044,7 +1044,7 @@
 	construction_time = 15
 	build_path = /obj/machinery/plumbing/splitter
 	category = list("Misc","Medical Designs")
-	departmental_flags = DEPARTMENTAL_FLAG_MEDICAL | DEPARTMENTAL_FLAG_SCIENCE
+	departmental_flags = DEPARTMENTAL_FLAG_SCIENCE
 
 /datum/design/pill_press
 	name = "Plumbing Automatic Pill Former"
@@ -1055,7 +1055,7 @@
 	construction_time = 15
 	build_path = /obj/machinery/plumbing/pill_press
 	category = list("Misc","Medical Designs")
-	departmental_flags = DEPARTMENTAL_FLAG_MEDICAL | DEPARTMENTAL_FLAG_SCIENCE
+	departmental_flags = DEPARTMENTAL_FLAG_SCIENCE
 
 /datum/design/plumb_pump
 	name = "Liquid Extraction Pump"
@@ -1066,7 +1066,7 @@
 	construction_time = 15
 	build_path = /obj/machinery/plumbing/liquid_pump
 	category = list("Misc","Medical Designs")
-	departmental_flags = DEPARTMENTAL_FLAG_MEDICAL | DEPARTMENTAL_FLAG_SCIENCE
+	departmental_flags = DEPARTMENTAL_FLAG_SCIENCE
 
 /datum/design/plumb_in
 	name = "Plumbing Input Device"
@@ -1077,7 +1077,7 @@
 	construction_time = 15
 	build_path = /obj/machinery/plumbing/input
 	category = list("Misc","Medical Designs")
-	departmental_flags = DEPARTMENTAL_FLAG_MEDICAL | DEPARTMENTAL_FLAG_SCIENCE
+	departmental_flags = DEPARTMENTAL_FLAG_SCIENCE
 
 /datum/design/plumb_out
 	name = "Plumbing Output Device"
@@ -1088,7 +1088,7 @@
 	construction_time = 15
 	build_path = /obj/machinery/plumbing/output
 	category = list("Misc","Medical Designs")
-	departmental_flags = DEPARTMENTAL_FLAG_MEDICAL | DEPARTMENTAL_FLAG_SCIENCE
+	departmental_flags = DEPARTMENTAL_FLAG_SCIENCE
 
 /datum/design/plumb_tank
 	name = "Plumbed Storage Tank"
@@ -1099,7 +1099,7 @@
 	construction_time = 15
 	build_path = /obj/machinery/plumbing/tank
 	category = list("Misc","Medical Designs")
-	departmental_flags = DEPARTMENTAL_FLAG_MEDICAL | DEPARTMENTAL_FLAG_SCIENCE
+	departmental_flags = DEPARTMENTAL_FLAG_SCIENCE
 
 /datum/design/plumb_rcd
 	name = "Plumbed Autoconstruction Device"
@@ -1110,7 +1110,7 @@
 	construction_time = 150
 	build_path = /obj/item/construction/plumbing
 	category = list("Misc","Medical Designs")
-	departmental_flags = DEPARTMENTAL_FLAG_MEDICAL | DEPARTMENTAL_FLAG_SCIENCE
+	departmental_flags = DEPARTMENTAL_FLAG_SCIENCE
 
 /datum/design/autosurgeon
 	name = "Autosurgeon"
@@ -1121,5 +1121,4 @@
 	construction_time = 100
 	build_path = /obj/item/autosurgeon
 	category = list("Misc","Medical Designs")
-	departmental_flags = DEPARTMENTAL_FLAG_MEDICAL | DEPARTMENTAL_FLAG_SCIENCE
-
+	departmental_flags = DEPARTMENTAL_FLAG_SCIENCE

--- a/code/modules/research/designs/misc_designs.dm
+++ b/code/modules/research/designs/misc_designs.dm
@@ -723,7 +723,7 @@
 	category = list("Equipment")
 	departmental_flags = DEPARTMENTAL_FLAG_ENGINEERING
 
-/datum/design/plasma_belt_tank
+/*/datum/design/plasma_belt_tank
 	name = "Plasmaman Belt Tank"
 	desc = "A small tank of plasma for plasmamen."
 	id = "plasmaman_tank_belt"
@@ -731,7 +731,7 @@
 	materials = list(/datum/material/iron = 1000)
 	build_path = /obj/item/tank/internals/plasmaman/belt/empty
 	category = list("Equipment")
-	departmental_flags = DEPARTMENTAL_FLAG_ENGINEERING
+	departmental_flags = DEPARTMENTAL_FLAG_ENGINEERING*/
 
 /datum/design/emergency_oxygen_engi
 	name = "Engineering Emergency Oxygen Tank"

--- a/code/modules/research/designs/power_designs.dm
+++ b/code/modules/research/designs/power_designs.dm
@@ -55,7 +55,7 @@
 	construction_time=100
 	build_path = /obj/item/stock_parts/cell/bluespace/empty
 	category = list("Misc","Power Designs")
-	departmental_flags = DEPARTMENTAL_FLAG_SCIENCE | DEPARTMENTAL_FLAG_ENGINEERING
+	departmental_flags = DEPARTMENTAL_FLAG_SCIENCE
 
 /datum/design/inducer
 	name = "Inducer"

--- a/code/modules/research/designs/stock_parts_designs.dm
+++ b/code/modules/research/designs/stock_parts_designs.dm
@@ -20,7 +20,7 @@
 	materials = list(/datum/material/iron = 15000, /datum/material/glass = 5000, /datum/material/silver = 2500) //hardcore
 	build_path = /obj/item/storage/part_replacer/bluespace
 	category = list("Stock Parts")
-	departmental_flags = DEPARTMENTAL_FLAG_ENGINEERING | DEPARTMENTAL_FLAG_SCIENCE
+	departmental_flags = DEPARTMENTAL_FLAG_SCIENCE
 
 //Capacitors
 /datum/design/basic_capacitor
@@ -65,7 +65,7 @@
 	build_path = /obj/item/stock_parts/capacitor/quadratic
 	category = list("Stock Parts")
 	lathe_time_factor = 0.2
-	departmental_flags = DEPARTMENTAL_FLAG_ENGINEERING | DEPARTMENTAL_FLAG_SCIENCE
+	departmental_flags = DEPARTMENTAL_FLAG_SCIENCE
 
 //Scanning modules
 /datum/design/basic_scanning
@@ -110,7 +110,7 @@
 	build_path = /obj/item/stock_parts/scanning_module/triphasic
 	category = list("Stock Parts")
 	lathe_time_factor = 0.2
-	departmental_flags = DEPARTMENTAL_FLAG_ENGINEERING | DEPARTMENTAL_FLAG_SCIENCE
+	departmental_flags = DEPARTMENTAL_FLAG_SCIENCE
 
 //Maipulators
 /datum/design/micro_mani
@@ -155,7 +155,7 @@
 	build_path = /obj/item/stock_parts/manipulator/femto
 	category = list("Stock Parts")
 	lathe_time_factor = 0.2
-	departmental_flags = DEPARTMENTAL_FLAG_ENGINEERING | DEPARTMENTAL_FLAG_SCIENCE
+	departmental_flags = DEPARTMENTAL_FLAG_SCIENCE
 
 //Micro-lasers
 /datum/design/basic_micro_laser
@@ -200,8 +200,9 @@
 	build_path = /obj/item/stock_parts/micro_laser/quadultra
 	category = list("Stock Parts")
 	lathe_time_factor = 0.2
-	departmental_flags = DEPARTMENTAL_FLAG_ENGINEERING | DEPARTMENTAL_FLAG_SCIENCE
+	departmental_flags = DEPARTMENTAL_FLAG_SCIENCE
 
+//Matter Bins
 /datum/design/basic_matter_bin
 	name = "Funnel"
 	desc = "A stock part used in the construction of various devices."
@@ -244,7 +245,7 @@
 	build_path = /obj/item/stock_parts/matter_bin/bluespace
 	category = list("Stock Parts")
 	lathe_time_factor = 0.2
-	departmental_flags = DEPARTMENTAL_FLAG_ENGINEERING | DEPARTMENTAL_FLAG_SCIENCE
+	departmental_flags = DEPARTMENTAL_FLAG_SCIENCE
 
 //T-Comms devices
 /datum/design/subspace_ansible

--- a/code/modules/research/designs/weapon_designs.dm
+++ b/code/modules/research/designs/weapon_designs.dm
@@ -214,7 +214,7 @@
 	materials = list(/datum/material/iron = 3500)
 	build_path = /obj/item/ammo_casing/shotgun/dart/noreact
 	category = list("Ammo")
-	departmental_flags = DEPARTMENTAL_FLAG_MEDICAL
+	departmental_flags = DEPARTMENTAL_FLAG_SCIENCE
 
 //////////////
 //Firing Pins/
@@ -576,7 +576,7 @@
 	materials = list(/datum/material/iron = 3000)
 	build_path = /obj/item/grenade/chem_grenade/large
 	category = list("Weapons")
-	departmental_flags = DEPARTMENTAL_FLAG_SECURITY | DEPARTMENTAL_FLAG_MEDICAL | DEPARTMENTAL_FLAG_SCIENCE
+	departmental_flags = DEPARTMENTAL_FLAG_SECURITY | DEPARTMENTAL_FLAG_SCIENCE
 
 /datum/design/pyro_grenade
 	name = "Pyro Grenade"
@@ -586,7 +586,7 @@
 	materials = list(/datum/material/iron = 2000, /datum/material/plasma = 500)
 	build_path = /obj/item/grenade/chem_grenade/pyro
 	category = list("Weapons")
-	departmental_flags = DEPARTMENTAL_FLAG_SECURITY | DEPARTMENTAL_FLAG_MEDICAL | DEPARTMENTAL_FLAG_SCIENCE
+	departmental_flags = DEPARTMENTAL_FLAG_SECURITY | DEPARTMENTAL_FLAG_SCIENCE
 
 /datum/design/cryo_grenade
 	name = "Cryo Grenade"
@@ -596,7 +596,7 @@
 	materials = list(/datum/material/iron = 2000, /datum/material/silver = 500)
 	build_path = /obj/item/grenade/chem_grenade/cryo
 	category = list("Weapons")
-	departmental_flags = DEPARTMENTAL_FLAG_SECURITY | DEPARTMENTAL_FLAG_MEDICAL | DEPARTMENTAL_FLAG_SCIENCE
+	departmental_flags = DEPARTMENTAL_FLAG_SECURITY | DEPARTMENTAL_FLAG_SCIENCE
 
 /datum/design/adv_grenade
 	name = "Advanced Release Grenade"
@@ -606,7 +606,7 @@
 	materials = list(/datum/material/iron = 3000, /datum/material/glass = 500)
 	build_path = /obj/item/grenade/chem_grenade/adv_release
 	category = list("Weapons")
-	departmental_flags = DEPARTMENTAL_FLAG_SECURITY | DEPARTMENTAL_FLAG_MEDICAL | DEPARTMENTAL_FLAG_SCIENCE
+	departmental_flags = DEPARTMENTAL_FLAG_SECURITY | DEPARTMENTAL_FLAG_SCIENCE
 
 ///////////
 //Shields//


### PR DESCRIPTION
## About The Pull Request
This is an attempt to make certain techfabs viable for use in maps by removing the worst abusive stuff that random wasters who aren't bound by faction rules should never be allowed access to. This does not actually spawn any techfabs/techfab boards anywhere. Two notes for this PR: Firstly, it works off the assumption that Science techfabs will never be used. I don't know what happens if you just delete the department_flags line and didn't feel like testing to find out, so anything that's bad got assigned to just the science techfab. Secondly, it is ONLY those two techfabs that have been touched. Security in particular would allow printing of all kinds of weapons and such, and I didn't feel like going through it (nor do I think giving them out would be good anyway). 

Changes:
Commented out Plasmaman jumpsuit refill and belt tank for everyone, including tech factions (SS13 items we don't need)
Removed medical tag from cloning disk and machine designs (Not actually printable, but just in case they do for whatever reason in the future)
Removed medical tag from all grenades (cryo grenade was the only one printable, but as above)
Removed medical tag from all plumbing designs (This is the main one)
Removed engineering tag from BRPED (Able to be abused, at least in previous versions)
Removed engineering tag from T4 parts (Still want tech factions to have the best and be able to trade them, don't want to deal with balance problems of NCR/Legion being able to print T4s. T3s can be found, this just makes it more reliable and repeatable.)


## Pre-Merge Checklist
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
<!-- Tick these after making the PR. -->

## Changelog
No player facing changes

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
