### PR TITLE
Energy Rebalance: Ballistics just weren't enough....

### DIFF
--- a/code/modules/projectiles/ammunition/energy/laser.dm
+++ b/code/modules/projectiles/ammunition/energy/laser.dm
@@ -300,7 +300,7 @@ also: most hitscan weapons have more charge than their normal projectile counter
 
 /obj/item/ammo_casing/energy/laser/aer14/hitscan
 	projectile_type = /obj/item/projectile/beam/laser/aer14/hitscan
-	e_cost = 100 //15 shots, i hate the decimal value too trust me
+	e_cost = 100 //10 shots
 
 /obj/item/ammo_casing/energy/laser/aer12
 	projectile_type = /obj/item/projectile/beam/laser/aer12
@@ -310,7 +310,7 @@ also: most hitscan weapons have more charge than their normal projectile counter
 
 /obj/item/ammo_casing/energy/laser/aer12/hitscan
 	projectile_type = /obj/item/projectile/beam/laser/aer12/hitscan
-	e_cost = 133.33 //8 shots.
+	e_cost = 133.33 //15 shots.
 	fire_sound = 'sound/f13weapons/aer9fire.ogg'
 	damage_threshold_penetration = 10 //Overcharged AF, lets at minimum 1/3rd of the damage it puts out burn through armor.
 

--- a/code/modules/projectiles/ammunition/energy/laser.dm
+++ b/code/modules/projectiles/ammunition/energy/laser.dm
@@ -117,7 +117,7 @@ also: most hitscan weapons have more charge than their normal projectile counter
 /obj/item/ammo_casing/energy/laser/scatter/tribeam/laserbuss
 	projectile_type = /obj/item/projectile/beam/laser/tribeam/laserbuss
 	pellets = 8
-	variance = 14
+	variance = SHOTGUN_SPREAD_BASE
 	select_name = "scatter"
 	e_cost = 187.5 //8 shots
 	fire_sound = 'sound/f13weapons/tribeamfire.ogg'

--- a/code/modules/projectiles/ammunition/energy/laser.dm
+++ b/code/modules/projectiles/ammunition/energy/laser.dm
@@ -300,7 +300,7 @@ also: most hitscan weapons have more charge than their normal projectile counter
 
 /obj/item/ammo_casing/energy/laser/aer14/hitscan
 	projectile_type = /obj/item/projectile/beam/laser/aer14/hitscan
-	e_cost = 133.33 //15 shots, i hate the decimal value too trust me
+	e_cost = 100 //15 shots, i hate the decimal value too trust me
 
 /obj/item/ammo_casing/energy/laser/aer12
 	projectile_type = /obj/item/projectile/beam/laser/aer12
@@ -310,7 +310,7 @@ also: most hitscan weapons have more charge than their normal projectile counter
 
 /obj/item/ammo_casing/energy/laser/aer12/hitscan
 	projectile_type = /obj/item/projectile/beam/laser/aer12/hitscan
-	e_cost = 250 //8 shots.
+	e_cost = 133.33 //8 shots.
 	fire_sound = 'sound/f13weapons/aer9fire.ogg'
 	damage_threshold_penetration = 10 //Overcharged AF, lets at minimum 1/3rd of the damage it puts out burn through armor.
 

--- a/code/modules/projectiles/ammunition/energy/laser.dm
+++ b/code/modules/projectiles/ammunition/energy/laser.dm
@@ -102,7 +102,7 @@ also: most hitscan weapons have more charge than their normal projectile counter
 /obj/item/ammo_casing/energy/laser/scatter/tribeam
 	projectile_type = /obj/item/projectile/beam/laser/tribeam
 	pellets = 3
-	variance = 70
+	variance = 14
 	select_name = "scatter"
 	e_cost = 180 //11 shots
 	fire_sound = 'sound/f13weapons/tribeamfire.ogg'
@@ -110,7 +110,7 @@ also: most hitscan weapons have more charge than their normal projectile counter
 /obj/item/ammo_casing/energy/laser/scatter/tribeam/hitscan
 	projectile_type = /obj/item/projectile/beam/laser/tribeam/hitscan
 	pellets = 3
-	variance = 300
+	variance = 38
 	select_name = "tribeam"
 	e_cost = 200 //10 shots
 

--- a/code/modules/projectiles/ammunition/energy/laser.dm
+++ b/code/modules/projectiles/ammunition/energy/laser.dm
@@ -110,7 +110,7 @@ also: most hitscan weapons have more charge than their normal projectile counter
 /obj/item/ammo_casing/energy/laser/scatter/tribeam/hitscan
 	projectile_type = /obj/item/projectile/beam/laser/tribeam/hitscan
 	pellets = 3
-	variance = 38
+	variance = SHOTGUN_SPREAD_BASE
 	select_name = "tribeam"
 	e_cost = 200 //10 shots
 

--- a/code/modules/projectiles/ammunition/energy/laser.dm
+++ b/code/modules/projectiles/ammunition/energy/laser.dm
@@ -102,7 +102,7 @@ also: most hitscan weapons have more charge than their normal projectile counter
 /obj/item/ammo_casing/energy/laser/scatter/tribeam
 	projectile_type = /obj/item/projectile/beam/laser/tribeam
 	pellets = 3
-	variance = 14
+	variance = 70
 	select_name = "scatter"
 	e_cost = 180 //11 shots
 	fire_sound = 'sound/f13weapons/tribeamfire.ogg'
@@ -110,7 +110,7 @@ also: most hitscan weapons have more charge than their normal projectile counter
 /obj/item/ammo_casing/energy/laser/scatter/tribeam/hitscan
 	projectile_type = /obj/item/projectile/beam/laser/tribeam/hitscan
 	pellets = 3
-	variance = 38
+	variance = 70
 	select_name = "tribeam"
 	e_cost = 200 //10 shots
 

--- a/code/modules/projectiles/ammunition/energy/laser.dm
+++ b/code/modules/projectiles/ammunition/energy/laser.dm
@@ -110,7 +110,7 @@ also: most hitscan weapons have more charge than their normal projectile counter
 /obj/item/ammo_casing/energy/laser/scatter/tribeam/hitscan
 	projectile_type = /obj/item/projectile/beam/laser/tribeam/hitscan
 	pellets = 3
-	variance = 70
+	variance = 300
 	select_name = "tribeam"
 	e_cost = 200 //10 shots
 

--- a/code/modules/projectiles/ammunition/energy/plasma.dm
+++ b/code/modules/projectiles/ammunition/energy/plasma.dm
@@ -29,7 +29,7 @@
 /obj/item/ammo_casing/energy/plasma/scatter
 	projectile_type = /obj/item/projectile/f13plasma/scatter
 	pellets = 3
-	variance = 14
+	variance = 80
 	select_name = "scatter"
 	fire_sound = 'sound/f13weapons/multiplas_rifle.ogg'
 	e_cost = 200 //10 shots

--- a/code/modules/projectiles/ammunition/energy/plasma.dm
+++ b/code/modules/projectiles/ammunition/energy/plasma.dm
@@ -29,7 +29,7 @@
 /obj/item/ammo_casing/energy/plasma/scatter
 	projectile_type = /obj/item/projectile/f13plasma/scatter
 	pellets = 3
-	variance = 14
+	variance = SHOTGUN_SPREAD_BASE
 	select_name = "scatter"
 	fire_sound = 'sound/f13weapons/multiplas_rifle.ogg'
 	e_cost = 200 //10 shots

--- a/code/modules/projectiles/ammunition/energy/plasma.dm
+++ b/code/modules/projectiles/ammunition/energy/plasma.dm
@@ -29,7 +29,7 @@
 /obj/item/ammo_casing/energy/plasma/scatter
 	projectile_type = /obj/item/projectile/f13plasma/scatter
 	pellets = 3
-	variance = 80
+	variance = 14
 	select_name = "scatter"
 	fire_sound = 'sound/f13weapons/multiplas_rifle.ogg'
 	e_cost = 200 //10 shots

--- a/code/modules/projectiles/ammunition/energy/special.dm
+++ b/code/modules/projectiles/ammunition/energy/special.dm
@@ -2,6 +2,7 @@
 	projectile_type = /obj/item/projectile/ion
 	select_name = "ion"
 	fire_sound = 'sound/f13weapons/pulsegunfire.ogg'
+	e_cost = 300 // 6 shots
 
 /obj/item/ammo_casing/energy/ion/hos
 	projectile_type = /obj/item/projectile/ion/weak

--- a/code/modules/projectiles/ammunition/energy/special.dm
+++ b/code/modules/projectiles/ammunition/energy/special.dm
@@ -2,7 +2,7 @@
 	projectile_type = /obj/item/projectile/ion
 	select_name = "ion"
 	fire_sound = 'sound/f13weapons/pulsegunfire.ogg'
-	e_cost = 300 // 6 shots
+	e_cost = 200 // 10 shots
 
 /obj/item/ammo_casing/energy/ion/hos
 	projectile_type = /obj/item/projectile/ion/weak

--- a/code/modules/projectiles/guns/energy/laser.dm
+++ b/code/modules/projectiles/guns/energy/laser.dm
@@ -579,16 +579,16 @@
 	zoom_factor = 1
 	equipsound = 'sound/f13weapons/equipsounds/aer14equip.ogg'
 
-	slowdown = GUN_SLOWDOWN_RIFLE_LIGHT_SEMI
+	slowdown = GUN_SLOWDOWN_RIFLE_MEDIUM_SEMI
 	force = GUN_MELEE_FORCE_RIFLE_LIGHT
 	weapon_weight = GUN_TWO_HAND_ONLY
 	draw_time = GUN_DRAW_LONG
-	fire_delay = GUN_FIRE_DELAY_SLOW
+	fire_delay = GUN_FIRE_DELAY_SLOWER
 	autofire_shot_delay = GUN_AUTOFIRE_DELAY_NORMAL
 	burst_shot_delay = GUN_BURSTFIRE_DELAY_NORMAL
 	burst_size = 1
 	init_firemodes = list(
-		/datum/firemode/semi_auto/slow
+		/datum/firemode/semi_auto/slower
 	)
 
 //Wattz 2000 Extended

--- a/code/modules/projectiles/guns/energy/laser.dm
+++ b/code/modules/projectiles/guns/energy/laser.dm
@@ -675,7 +675,7 @@
 	burst_size = 1
 	gun_tags = list(GUN_SCOPE)
 	can_scope = TRUE
-	init_recoil = RIFLE_RECOIL(2.8)
+	init_recoil = RIFLE_RECOIL(1)recoil
 	init_firemodes = list(
 		/datum/firemode/semi_auto/slow
 	)

--- a/code/modules/projectiles/guns/energy/laser.dm
+++ b/code/modules/projectiles/guns/energy/laser.dm
@@ -675,7 +675,7 @@
 	burst_size = 1
 	gun_tags = list(GUN_SCOPE)
 	can_scope = TRUE
-	init_recoil = RIFLE_RECOIL(1)recoil
+	init_recoil = RIFLE_RECOIL(1)
 	init_firemodes = list(
 		/datum/firemode/semi_auto/slow
 	)

--- a/code/modules/projectiles/guns/energy/laser.dm
+++ b/code/modules/projectiles/guns/energy/laser.dm
@@ -690,14 +690,14 @@
 	force = GUN_MELEE_FORCE_RIFLE_HEAVY
 	weapon_weight = GUN_TWO_HAND_ONLY
 	draw_time = GUN_DRAW_LONG
-	fire_delay = GUN_FIRE_DELAY_SLOWER
+	fire_delay = GUN_FIRE_DELAY_SLOW
 	autofire_shot_delay = GUN_AUTOFIRE_DELAY_NORMAL
 	burst_shot_delay = GUN_BURSTFIRE_DELAY_NORMAL
 	burst_size = 1
 	gun_tags = list(GUN_SCOPE)
 	can_scope = TRUE
 	init_firemodes = list(
-		/datum/firemode/semi_auto/slower
+		/datum/firemode/semi_auto/slow
 	)
 
 //Ultracite Laser rifle
@@ -789,14 +789,14 @@
 	force = GUN_MELEE_FORCE_RIFLE_HEAVY
 	weapon_weight = GUN_TWO_HAND_ONLY
 	draw_time = GUN_DRAW_LONG
-	fire_delay = GUN_FIRE_DELAY_SLOW
+	fire_delay = GUN_FIRE_DELAY_NORMAL
 	autofire_shot_delay = GUN_AUTOFIRE_DELAY_NORMAL
 	burst_shot_delay = GUN_BURSTFIRE_DELAY_NORMAL
 	burst_size = 1
 	gun_tags = list(GUN_SCOPE)
 	can_scope = TRUE
 	init_firemodes = list(
-		/datum/firemode/semi_auto/slow
+		/datum/firemode/semi_auto
 	)
 
 //LAER Energy rifle

--- a/code/modules/projectiles/guns/energy/laser.dm
+++ b/code/modules/projectiles/guns/energy/laser.dm
@@ -764,6 +764,7 @@
 	slowdown = GUN_SLOWDOWN_RIFLE_MEDIUM_SEMI
 	force = GUN_MELEE_FORCE_RIFLE_HEAVY
 	weapon_weight = GUN_TWO_HAND_ONLY
+	init_recoil = RIFLE_RECOIL(5)
 	draw_time = GUN_DRAW_LONG
 	fire_delay = GUN_FIRE_DELAY_SLOWER * 0.9 //too slow.
 	autofire_shot_delay = GUN_AUTOFIRE_DELAY_NORMAL

--- a/code/modules/projectiles/guns/energy/laser.dm
+++ b/code/modules/projectiles/guns/energy/laser.dm
@@ -675,7 +675,6 @@
 	burst_size = 1
 	gun_tags = list(GUN_SCOPE)
 	can_scope = TRUE
-	init_recoil = RIFLE_RECOIL(1)
 	init_firemodes = list(
 		/datum/firemode/semi_auto/slow
 	)

--- a/code/modules/projectiles/guns/energy/laser.dm
+++ b/code/modules/projectiles/guns/energy/laser.dm
@@ -675,6 +675,7 @@
 	burst_size = 1
 	gun_tags = list(GUN_SCOPE)
 	can_scope = TRUE
+	init_recoil = RIFLE_RECOIL(2.8)
 	init_firemodes = list(
 		/datum/firemode/semi_auto/slow
 	)
@@ -739,6 +740,7 @@
 	slowdown = GUN_SLOWDOWN_RIFLE_MEDIUM_SEMI
 	force = GUN_MELEE_FORCE_RIFLE_HEAVY
 	weapon_weight = GUN_TWO_HAND_ONLY
+	init_recoil = RIFLE_RECOIL(5)
 	draw_time = GUN_DRAW_LONG
 	fire_delay = GUN_FIRE_DELAY_SLOWER * 0.9 //too slow.
 	autofire_shot_delay = GUN_AUTOFIRE_DELAY_NORMAL

--- a/code/modules/projectiles/guns/energy/plasmaf13.dm
+++ b/code/modules/projectiles/guns/energy/plasmaf13.dm
@@ -205,6 +205,7 @@
 	slowdown = GUN_SLOWDOWN_RIFLE_MEDIUM_SEMI
 	force = GUN_MELEE_FORCE_PISTOL_LIGHT
 	weapon_weight = GUN_TWO_HAND_ONLY
+	init_recoil = RIFLE_RECOIL(5)
 	draw_time = GUN_DRAW_LONG
 	fire_delay = GUN_FIRE_DELAY_SLOWER
 	autofire_shot_delay = GUN_AUTOFIRE_DELAY_NORMAL

--- a/code/modules/projectiles/projectile/beams.dm
+++ b/code/modules/projectiles/projectile/beams.dm
@@ -524,6 +524,7 @@
 
 /obj/item/projectile/beam/laser/tribeam/hitscan
 	name = "tribeam laser"
+	recoil = 25
 	damage = 25 //if all bullets connect, this will do 75.
 	hitscan = TRUE
 	bare_wound_bonus = -30 //tribeam is bad at wounding, as basically its only real downside

--- a/code/modules/projectiles/projectile/beams.dm
+++ b/code/modules/projectiles/projectile/beams.dm
@@ -294,7 +294,7 @@
 	damage = 45
 	hitscan = TRUE
 	armour_penetration = 0.5 //rare laser to have AP, to offset single-fire
-	pixels_per_second = TILES_TO_PIXELS(70)
+	pixels_per_second = TILES_TO_PIXELS(130)
 
 //plasma caster
 /obj/item/projectile/f13plasma/plasmacaster
@@ -305,7 +305,7 @@
 	flag = "energy"
 	eyeblur = 0
 	is_reflectable = TRUE
-	pixels_per_second = TILES_TO_PIXELS(70)
+	pixels_per_second = TILES_TO_PIXELS(130)
 
 //Securitrons Beam
 /obj/item/projectile/beam/laser/pistol/ultraweak
@@ -327,7 +327,7 @@
 	flag = "laser"
 	eyeblur = 0
 	is_reflectable = FALSE
-	pixels_per_second = TILES_TO_PIXELS(70)
+	pixels_per_second = TILES_TO_PIXELS(130)
 
 /obj/item/projectile/beam/laser/lasgun //AER9
 	name = "laser beam"

--- a/code/modules/projectiles/projectile/beams.dm
+++ b/code/modules/projectiles/projectile/beams.dm
@@ -294,7 +294,7 @@
 	damage = 45
 	hitscan = TRUE
 	armour_penetration = 0.5 //rare laser to have AP, to offset single-fire
-	pixels_per_second = TILES_TO_PIXELS(130)
+	pixels_per_second = TILES_TO_PIXELS(50)
 
 //plasma caster
 /obj/item/projectile/f13plasma/plasmacaster
@@ -305,7 +305,7 @@
 	flag = "energy"
 	eyeblur = 0
 	is_reflectable = TRUE
-	pixels_per_second = TILES_TO_PIXELS(130)
+	pixels_per_second = TILES_TO_PIXELS(100)
 
 //Securitrons Beam
 /obj/item/projectile/beam/laser/pistol/ultraweak
@@ -327,7 +327,7 @@
 	flag = "laser"
 	eyeblur = 0
 	is_reflectable = FALSE
-	pixels_per_second = TILES_TO_PIXELS(130)
+	pixels_per_second = TILES_TO_PIXELS(100)
 
 /obj/item/projectile/beam/laser/lasgun //AER9
 	name = "laser beam"

--- a/code/modules/projectiles/projectile/beams.dm
+++ b/code/modules/projectiles/projectile/beams.dm
@@ -631,6 +631,7 @@
 
 /obj/item/projectile/f13plasma/scatter //Multiplas, fires 3 shots, will melt you
 	damage = 35
+	recoil = 25
 
 /obj/item/projectile/beam/laser/rcw //RCW
 	name = "rapidfire beam"

--- a/code/modules/projectiles/projectile/beams.dm
+++ b/code/modules/projectiles/projectile/beams.dm
@@ -314,7 +314,7 @@
 //Chewchews Beam
 /obj/item/projectile/beam/laser/pistol/ultraweak/chewchew
 	damage = 13 //less dam..
-	armour_penetration = 0.25 //..more pen
+	armour_penetration = 0.75 //..more pen
 	is_reflectable = FALSE
 
 //Alrem's plasmacaster

--- a/code/modules/projectiles/projectile/beams.dm
+++ b/code/modules/projectiles/projectile/beams.dm
@@ -305,7 +305,7 @@
 	flag = "energy"
 	eyeblur = 0
 	is_reflectable = TRUE
-	pixels_per_second = TILES_TO_PIXELS(85)
+	pixels_per_second = TILES_TO_PIXELS(80)
 
 //Securitrons Beam
 /obj/item/projectile/beam/laser/pistol/ultraweak
@@ -327,7 +327,7 @@
 	flag = "laser"
 	eyeblur = 0
 	is_reflectable = FALSE
-	pixels_per_second = TILES_TO_PIXELS(85)
+	pixels_per_second = TILES_TO_PIXELS(80)
 
 /obj/item/projectile/beam/laser/lasgun //AER9
 	name = "laser beam"
@@ -685,7 +685,7 @@
 /obj/item/projectile/beam/laser/aer14 //AER14
 	name = "laser beam"
 	damage = 38
-	armour_penetration = 0.25
+	armour_penetration = 0.6
 	icon_state = "omnilaser"
 	impact_effect_type = /obj/effect/temp_visual/impact_effect/blue_laser
 	light_color = LIGHT_COLOR_BLUE

--- a/code/modules/projectiles/projectile/beams.dm
+++ b/code/modules/projectiles/projectile/beams.dm
@@ -538,6 +538,7 @@
 
 /obj/item/projectile/beam/laser/tribeam/laserbuss/hitscan
 	name = "tribeam laser"
+	recoil = 25
 	damage = 20
 	hitscan = TRUE
 	bare_wound_bonus = -30 //tribeam is bad at wounding, as basically its only real downside

--- a/code/modules/projectiles/projectile/beams.dm
+++ b/code/modules/projectiles/projectile/beams.dm
@@ -301,7 +301,7 @@
 	name = "plasma bolt"
 	icon_state = "plasma_clot"
 	damage_type = BURN
-	damage = 60
+	damage = 55
 	flag = "energy"
 	eyeblur = 0
 	is_reflectable = TRUE
@@ -322,7 +322,7 @@
 	name = "plasma bolt"
 	icon_state = "plasma_clot"
 	damage_type = BURN
-	damage = 60
+	damage = 55
 	armour_penetration = 0.8
 	flag = "laser"
 	eyeblur = 0
@@ -335,8 +335,8 @@
 
 /obj/item/projectile/beam/laser/lasgun/hitscan //hitscan aer9 test
 	name = "laser beam"
-	damage = 32
-	armour_penetration = 0.1 //mostly just to allow scratch damage, so you arent SOL just mostly fucced
+	damage = 30
+	armour_penetration = 0.08 //mostly just to allow scratch damage, so you arent SOL just mostly fucced
 	hitscan = TRUE
 	tracer_type = /obj/effect/projectile/tracer/laser
 	muzzle_type = /obj/effect/projectile/muzzle/laser
@@ -718,7 +718,7 @@
 
 /obj/item/projectile/beam/laser/aer12/hitscan
 	name = "laser beam"
-	damage = 36
+	damage = 32
 	hitscan = TRUE
 	armour_penetration = 0.2
 	tracer_type = /obj/effect/projectile/tracer/xray
@@ -741,7 +741,7 @@
 
 /obj/item/projectile/beam/laser/wattz2k/hitscan
 	name = "sniper laser bolt"
-	damage = 52
+	damage = 50
 	wound_bonus = 10
 	bare_wound_bonus = 20
 	armour_penetration = 0.2

--- a/code/modules/projectiles/projectile/beams.dm
+++ b/code/modules/projectiles/projectile/beams.dm
@@ -305,7 +305,7 @@
 	flag = "energy"
 	eyeblur = 0
 	is_reflectable = TRUE
-	pixels_per_second = TILES_TO_PIXELS(100)
+	pixels_per_second = TILES_TO_PIXELS(85)
 
 //Securitrons Beam
 /obj/item/projectile/beam/laser/pistol/ultraweak
@@ -327,7 +327,7 @@
 	flag = "laser"
 	eyeblur = 0
 	is_reflectable = FALSE
-	pixels_per_second = TILES_TO_PIXELS(100)
+	pixels_per_second = TILES_TO_PIXELS(85)
 
 /obj/item/projectile/beam/laser/lasgun //AER9
 	name = "laser beam"

--- a/code/modules/projectiles/projectile/beams.dm
+++ b/code/modules/projectiles/projectile/beams.dm
@@ -720,7 +720,7 @@
 	name = "laser beam"
 	damage = 36
 	hitscan = TRUE
-	armour_penetration = 0.25
+	armour_penetration = 0.2
 	tracer_type = /obj/effect/projectile/tracer/xray
 	muzzle_type = /obj/effect/projectile/muzzle/xray
 	impact_type = /obj/effect/projectile/impact/xray

--- a/code/modules/projectiles/projectile/beams.dm
+++ b/code/modules/projectiles/projectile/beams.dm
@@ -294,7 +294,7 @@
 	damage = 45
 	hitscan = TRUE
 	armour_penetration = 0.5 //rare laser to have AP, to offset single-fire
-	pixels_per_second = TILES_TO_PIXELS(50)
+	pixels_per_second = TILES_TO_PIXELS(70)
 
 //plasma caster
 /obj/item/projectile/f13plasma/plasmacaster
@@ -305,7 +305,7 @@
 	flag = "energy"
 	eyeblur = 0
 	is_reflectable = TRUE
-	pixels_per_second = TILES_TO_PIXELS(50)
+	pixels_per_second = TILES_TO_PIXELS(70)
 
 //Securitrons Beam
 /obj/item/projectile/beam/laser/pistol/ultraweak
@@ -327,7 +327,7 @@
 	flag = "laser"
 	eyeblur = 0
 	is_reflectable = FALSE
-	pixels_per_second = TILES_TO_PIXELS(50)
+	pixels_per_second = TILES_TO_PIXELS(70)
 
 /obj/item/projectile/beam/laser/lasgun //AER9
 	name = "laser beam"

--- a/code/modules/projectiles/projectile/beams.dm
+++ b/code/modules/projectiles/projectile/beams.dm
@@ -336,7 +336,7 @@
 /obj/item/projectile/beam/laser/lasgun/hitscan //hitscan aer9 test
 	name = "laser beam"
 	damage = 32
-	armour_penetration = 0.02 //mostly just to allow scratch damage, so you arent SOL just mostly fucced
+	armour_penetration = 0.1 //mostly just to allow scratch damage, so you arent SOL just mostly fucced
 	hitscan = TRUE
 	tracer_type = /obj/effect/projectile/tracer/laser
 	muzzle_type = /obj/effect/projectile/muzzle/laser
@@ -641,6 +641,7 @@
 	name = "rapidfire beam"
 	icon_state = "emitter"
 	damage = 19
+	armour_penetration = 0.05
 	hitscan = TRUE
 	muzzle_type = /obj/effect/projectile/muzzle/laser/emitter
 	tracer_type = /obj/effect/projectile/tracer/laser/emitter
@@ -684,7 +685,7 @@
 /obj/item/projectile/beam/laser/aer14 //AER14
 	name = "laser beam"
 	damage = 38
-	armour_penetration = 0.6
+	armour_penetration = 0.25
 	icon_state = "omnilaser"
 	impact_effect_type = /obj/effect/temp_visual/impact_effect/blue_laser
 	light_color = LIGHT_COLOR_BLUE
@@ -692,7 +693,7 @@
 /obj/item/projectile/beam/laser/aer14/hitscan
 	damage = 32
 	wound_bonus = 20
-	armour_penetration = 0.05
+	armour_penetration = 0.2
 	tracer_type = /obj/effect/projectile/tracer/pulse
 	muzzle_type = /obj/effect/projectile/muzzle/pulse
 	impact_type = /obj/effect/projectile/impact/pulse
@@ -719,7 +720,7 @@
 	name = "laser beam"
 	damage = 36
 	hitscan = TRUE
-	armour_penetration = 0.5
+	armour_penetration = 0.25
 	tracer_type = /obj/effect/projectile/tracer/xray
 	muzzle_type = /obj/effect/projectile/muzzle/xray
 	impact_type = /obj/effect/projectile/impact/xray

--- a/code/modules/projectiles/projectile/special/ion.dm
+++ b/code/modules/projectiles/projectile/special/ion.dm
@@ -1,12 +1,12 @@
 /obj/item/projectile/ion
 	name = "ion bolt"
 	icon_state = "ion"
-	damage = 28
-	armour_penetration = 0.75
+	damage = 25
+	armour_penetration = 0.6
 	damage_type = BURN
 	flag = "energy"
 	impact_effect_type = /obj/effect/temp_visual/impact_effect/ion
-	var/emp_radius = 2
+	var/emp_radius = 1
 
 /obj/item/projectile/ion/on_hit(atom/target, blocked = FALSE)
 	..()


### PR DESCRIPTION
## About The Pull Request
Energy weapons weren't bad, but they weren't very unique and didn't serve a niche. They were basically mid-tier ballistics with hitscan - not even hitscan in the case of the plasma rifle. This PR looks to fix up some of the underpowered energy weapons and increase uniqueness in the blander firearms.

Specifically, the AER weapons were all basically the same gun, a mid-tier rifle. This stages out the guns so they have some uniqueness and variance; the AER9 fills the role of a basic low tier laser gun with 8% AP, 25 shot MFC capacity and a meh fire rate. The AER12 fills the role of a mid-tier laser gun specialized in armour penetration, dealing significantly higher AP at 20%, but having 10 less ammunition per MFC than the AER9. The AER14 is the high tier laser gun, with a higher fire rate than both prior guns, 20% AP and 20 shots per MFC. Furthermore, the Laser RCW has been given 5% armour penetration to offset the comparatively low damage (when compared to other mid to high tier SMGs) and bring it in line with other energy weapons.

Other changes include some speeding up of the plasma projectile so it isn't insanely easy to dodge for anyone with four fingers on their left hand, a buff of the chew chew's armour penetration to be actually high to justify it's insanely low damage.

Additionally, for some reason the YK pulse rifle (ion rifle) had like 15 shots per MFC, an insane fire rate, good damage and 75% armour pen. It's been nerfed slightly, as well as having it's ion radius fixed so it doesn't drain energy cells on the user.

The Wattz 2000 has been given slowdown and fire rate in line with similar sniper rifles.

If you want exact numbers on how many shots a specific gun takes to kill against specific armours, feel free to message me.

ADDENDUM: Tribeam, multiplas and laserbuss fixed. Ignore the insane recoil values, it's the only way for it not to be deadeye accurate every shot with 100 energy weapons. Also, base damage was lowered on all energy weapons to accommodate for the realization that they have no recoil. Adjustments are pretty marginal, and bring laser weapons in line with the improvised ammunition types for weapons of their equivalent.

## Pre-Merge Checklist
- [X] You tested this on a local server.
- [X] This code did not runtime during testing.
- [X] You documented all of your changes.
<!-- Tick these after making the PR. -->

## Changelog
:cl:
fix: Tribeam is no longer perfectly accurate.
fix: Multiplas is no longer perfectly accurate.
fix: Laserbuss is no longer perfectly accurate.
fix: YK ion radius changed from 2 to 1 so it doesn't drain user's energy cells.
balance: YK MFC capacity changed from 15 to 10, armour pen from 75% to 60%, damage from 28 to 25.
balance: AER9 armour pen increased from 2% to 8%
balance: AER12 fire rate increased, AP decreased from 55% to 20%, shot count increased from 8 to 15
balance: AER14 fire rate increased, AP increased to 20%, shot count increased from 15 to 20
balance: Chew-chew given 75% AP to make up for shooting literal piss lasers (13 damage lol).
balance: RCW given 5% AP
balance: Plasma projectiles sped up slightly
balance: Wattz 2000 lowered fire rate + increased slowdown to make it an actual sniper instead of a rifle.
balance: Lowered overall base damage to accommodate for the lack of recoil in all energy weapons.
/:cl:
