### PR TITLE
Minigun and Gatling Laser loot integration

### DIFF
--- a/code/game/objects/effects/spawners/f13lootdrop.dm
+++ b/code/game/objects/effects/spawners/f13lootdrop.dm
@@ -784,6 +784,7 @@
 				/obj/effect/spawner/bundle/f13/rcw = 20,
 				/obj/effect/spawner/bundle/f13/wattz2kext = 10, //Now a high tier gun.
 				/obj/effect/spawner/bundle/f13/plasmaglock = 20
+				/obj/item/minigunpack = 10 = 20
 				)
 
 /obj/effect/spawner/lootdrop/f13/weapon/gun/energy/superhigh
@@ -917,6 +918,7 @@
 				/obj/effect/spawner/bundle/f13/riotshotgun = 10,
 				/obj/item/gun/ballistic/shotgun/automatic/combat/citykiller = 10,
 				/obj/effect/spawner/bundle/f13/guns/p90 = 2,
+				/obj/item/minigunpackbal5mm = 10
 				)
 
 

--- a/code/game/objects/effects/spawners/f13lootdrop.dm
+++ b/code/game/objects/effects/spawners/f13lootdrop.dm
@@ -783,8 +783,8 @@
 				/obj/effect/spawner/bundle/f13/tribeam = 20,
 				/obj/effect/spawner/bundle/f13/rcw = 20,
 				/obj/effect/spawner/bundle/f13/wattz2kext = 10, //Now a high tier gun.
-				/obj/effect/spawner/bundle/f13/plasmaglock = 20
-				/obj/item/minigunpack = 10 = 20
+				/obj/effect/spawner/bundle/f13/plasmaglock = 20,
+				/obj/item/minigunpack = 20
 				)
 
 /obj/effect/spawner/lootdrop/f13/weapon/gun/energy/superhigh
@@ -918,7 +918,6 @@
 				/obj/effect/spawner/bundle/f13/riotshotgun = 10,
 				/obj/item/gun/ballistic/shotgun/automatic/combat/citykiller = 10,
 				/obj/effect/spawner/bundle/f13/guns/p90 = 2,
-				/obj/item/minigunpackbal5mm = 10
 				)
 
 
@@ -933,7 +932,8 @@
 				/obj/effect/spawner/bundle/f13/fnfal = 10,
 				/obj/item/gun/ballistic/rocketlauncher = 10,
 				/obj/item/gun/ballistic/automatic/bozar = 10,
-				/obj/effect/spawner/bundle/f13/infiltrator = 15
+				/obj/effect/spawner/bundle/f13/infiltrator = 15,
+				/obj/item/minigunpackbal5mm = 10
 				)
 
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ballistic/superhighcargo //this loot table is for the prewar cargo crate


### PR DESCRIPTION
## About The Pull Request
Minigun and Gatling Laser were not in loot tables. That has been fixed.

## Pre-Merge Checklist
- [X] You tested this on a local server.
- [X] This code did not runtime during testing.
- [X] You documented all of your changes.
<!-- Tick these after making the PR. -->

## Changelog
:cl:
add: Minigun now spawns in superhigh tier ballistic loot, gatling laser spawns in high energy loot.
/:cl:
