### PR TITLE
Nerfs Ion arrow and EMP grenade availability

### DIFF
--- a/code/datums/components/crafting/recipes/recipes_primal.dm
+++ b/code/datums/components/crafting/recipes/recipes_primal.dm
@@ -377,8 +377,9 @@
 	name = "Ion-Spirit Arrow"
 	result = /obj/item/ammo_casing/caseless/arrow/ion
 	time = 30
-	reqs = list(/obj/item/stack/crafting/electronicparts = 3,
-				/obj/item/stack/rods = 2)
+	reqs = list(/obj/item/stock_parts/cell/ammo/mfc = 1,
+				/obj/item/stack/cable_coil = 2,
+				/obj/item/stack/rods = 1)
 	category = CAT_TRIBAL
 	tools = list(TOOL_WORKBENCH)
 

--- a/code/datums/traits/good.dm
+++ b/code/datums/traits/good.dm
@@ -21,7 +21,6 @@ GLOBAL_LIST_INIT(adv_explosive_recipes, list(
 	/datum/crafting_recipe/incendiary,
 	/datum/crafting_recipe/concussion,
 	/datum/crafting_recipe/radgrenade,
-	/datum/crafting_recipe/empgrenade,
 	/datum/crafting_recipe/incendiaryrocket,
 	/datum/crafting_recipe/strongrocket))
 

--- a/code/game/objects/effects/spawners/f13lootdrop.dm
+++ b/code/game/objects/effects/spawners/f13lootdrop.dm
@@ -2143,6 +2143,7 @@ obj/effect/spawner/bundle/f13/combat_rifle
 	lootcount = 1
 	loot = list(
 		/obj/item/book/granter/crafting_recipe/blueprint/leveraction,
+		/obj/item/book/granter/crafting_recipe/blueprint/empgrenade,
 		/obj/item/book/granter/crafting_recipe/blueprint/r91,
 		/obj/item/book/granter/crafting_recipe/blueprint/r84,
 		/obj/item/book/granter/crafting_recipe/blueprint/deagle,

--- a/code/game/objects/effects/spawners/f13lootdrop.dm
+++ b/code/game/objects/effects/spawners/f13lootdrop.dm
@@ -1670,8 +1670,7 @@ obj/effect/spawner/bundle/f13/combat_rifle
 	loot = list(
 				/obj/item/grenade/f13/frag = 30,
 				/obj/item/grenade/flashbang,
-				/obj/item/grenade/f13/stinger,
-				/obj/item/grenade/empgrenade = 50
+				/obj/item/grenade/f13/stinger
 				)
 
 /obj/effect/spawner/lootdrop/f13/bomb/tier3

--- a/code/game/objects/items/granters.dm
+++ b/code/game/objects/items/granters.dm
@@ -721,6 +721,11 @@
 	icon_state = "blueprint2"
 	crafting_recipe_types = list(/datum/crafting_recipe/lever_action)
 
+/obj/item/book/granter/crafting_recipe/blueprint/empgrenade
+	name = "EMP grenade blueprint"
+	icon_state = "blueprint2"
+	crafting_recipe_types = list(/datum/crafting_recipe/empgrenade)
+
 /obj/item/book/granter/crafting_recipe/blueprint/trailcarbine
 	name = "trail carbine blueprint"
 	icon_state = "blueprint2"

--- a/code/modules/jobs/job_types/legion.dm
+++ b/code/modules/jobs/job_types/legion.dm
@@ -1060,7 +1060,6 @@ Weapons		Lever shotgun, Grease gun, Repeater carbines, Revolvers, simple guns al
 	H.mind.teach_crafting_recipe(/datum/crafting_recipe/legionlance)
 	H.mind.teach_crafting_recipe(/datum/crafting_recipe/concussion)
 	H.mind.teach_crafting_recipe(/datum/crafting_recipe/strongrocket)
-	H.mind.teach_crafting_recipe(/datum/crafting_recipe/empgrenade)
 	H.mind.teach_crafting_recipe(/datum/crafting_recipe/tribalwar/xbow)
 	H.mind.teach_crafting_recipe(/datum/crafting_recipe/tribalwar/cheaparrow)
 

--- a/code/modules/jobs/job_types/ncr.dm
+++ b/code/modules/jobs/job_types/ncr.dm
@@ -1543,7 +1543,6 @@ Weapons		Service Rifle, Grease Gun, 9mm pistol, all good.
 	H.mind.teach_crafting_recipe(/datum/crafting_recipe/ncrsalvagedhelmetconversion)
 	H.mind.teach_crafting_recipe(/datum/crafting_recipe/concussion)
 	H.mind.teach_crafting_recipe(/datum/crafting_recipe/incendiaryrocket)
-	H.mind.teach_crafting_recipe(/datum/crafting_recipe/empgrenade)
 	//guns
 	H.mind.teach_crafting_recipe(/datum/crafting_recipe/dks)
 	H.mind.teach_crafting_recipe(/datum/crafting_recipe/a180)


### PR DESCRIPTION
## About The Pull Request
Ion arrows were incredibly busted, providing an EMP for 2 electronic parts. As opposed to removing them, they have been nerfed to require an MFC per arrow.
EMP Grenades have been removed from the advanced ammo book and placed in their own dedicated crafting blueprint, shoved in the high tier blueprint loot table, aswell as removed from camp follower and logistical officer (rip LO o7) inheret job traits, aswell as taken from the t2 bomb loot pool. They're now a rare find, instead of a medium-rare one.

## Pre-Merge Checklist
- [ ] You tested this on a local server.
- [ ] This code did not runtime during testing.
- [ ] You documented all of your changes.
<!-- Tick these after making the PR. -->

## Changelog
:cl:
balances: above mentioned recipies
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
