### PR TITLE
More Laser Adjustments

### DIFF
--- a/code/modules/projectiles/projectile/beams.dm
+++ b/code/modules/projectiles/projectile/beams.dm
@@ -335,8 +335,8 @@
 
 /obj/item/projectile/beam/laser/lasgun/hitscan //hitscan aer9 test
 	name = "laser beam"
-	damage = 30
-	armour_penetration = 0.08 //mostly just to allow scratch damage, so you arent SOL just mostly fucced
+	damage = 25
+	armour_penetration = 0.1 //mostly just to allow scratch damage, so you arent SOL just mostly fucced
 	hitscan = TRUE
 	tracer_type = /obj/effect/projectile/tracer/laser
 	muzzle_type = /obj/effect/projectile/muzzle/laser
@@ -350,7 +350,7 @@
 /obj/item/projectile/beam/laser/gatling/hitscan //Gatling Laser
 	name = "laser beam"
 	damage = 15
-	armour_penetration = 0
+	/* armour_penetration = 0 */
 	hitscan = TRUE
 	tracer_type = /obj/effect/projectile/tracer/laser
 	muzzle_type = /obj/effect/projectile/muzzle/laser
@@ -643,8 +643,8 @@
 /obj/item/projectile/beam/laser/rcw/hitscan //RCW
 	name = "rapidfire beam"
 	icon_state = "emitter"
-	damage = 19
-	armour_penetration = 0.05
+	damage = 18
+	/* armour_penetration = 0.05 */
 	hitscan = TRUE
 	muzzle_type = /obj/effect/projectile/muzzle/laser/emitter
 	tracer_type = /obj/effect/projectile/tracer/laser/emitter
@@ -694,8 +694,8 @@
 	light_color = LIGHT_COLOR_BLUE
 
 /obj/item/projectile/beam/laser/aer14/hitscan
-	damage = 32
-	wound_bonus = 20
+	damage = 30
+	wound_bonus = 10
 	armour_penetration = 0.2
 	tracer_type = /obj/effect/projectile/tracer/pulse
 	muzzle_type = /obj/effect/projectile/muzzle/pulse
@@ -721,7 +721,7 @@
 
 /obj/item/projectile/beam/laser/aer12/hitscan
 	name = "laser beam"
-	damage = 32
+	damage = 28
 	hitscan = TRUE
 	armour_penetration = 0.2
 	tracer_type = /obj/effect/projectile/tracer/xray
@@ -744,14 +744,15 @@
 
 /obj/item/projectile/beam/laser/wattz2k/hitscan
 	name = "sniper laser bolt"
-	damage = 50
+	damage = 45
 	wound_bonus = 10
 	bare_wound_bonus = 20
-	armour_penetration = 0.2
+	armour_penetration = 0.1
 	tracer_type = /obj/effect/projectile/tracer/heavy_laser
 	muzzle_type = /obj/effect/projectile/muzzle/heavy_laser
 	impact_type = /obj/effect/projectile/impact/heavy_laser
 	hitscan = TRUE
+	
 /obj/item/projectile/beam/laser/wattz2k/hitscan/weak //Hits less than the main wattz2k with less AP but has more shots comparable to an aer9
 	name = "weak sniper laser bolt"
 	damage = 40


### PR DESCRIPTION
## About The Pull Request
So. Turns out that BYOND can't handle decimals to the hundredth, and will round them either up or down to the tenth. As such, AP on the AER9 is either 10% or 0%. As such, it's damage has been dropped a fair bit. Furthermore, damage on the rest of the guns has been dropped by 4-5 points to accommodate for the fact that AP is very strong, while allowing energy weapons to keep their unique traits.

May require further testing to keep laser weapons balanced. The goal here is not to recreate their exact role in the fallout games, but instead to have them fulfill a niche while still being viable as a standard weapon, as they are the powerhorse of one of the largest factions. Feel free to provide criticisms or recommendations, but I would prefer that people test the changes before providing their opinions :).

## Pre-Merge Checklist
- [X] You tested this on a local server.
- [X] This code did not runtime during testing.
- [X] You documented all of your changes.
<!-- Tick these after making the PR. -->

## Changelog
:cl:
balance: adjusted damage across all laser weapons in rotation
closes: #182
/:cl:
