### PR TITLE
Laserbuss Obliteration

### DIFF
--- a/code/game/objects/effects/spawners/f13lootdrop.dm
+++ b/code/game/objects/effects/spawners/f13lootdrop.dm
@@ -798,7 +798,7 @@
 	lootcount = 1
 
 	loot = list(/obj/item/gun/energy/laser/solar,
-				/obj/item/gun/energy/laser/scatter/laserbuss,
+				/* /obj/item/gun/energy/laser/scatter/laserbuss, */
 				/obj/item/gun/energy/laser/plasma/pistol/eve,
 				/obj/item/gun/energy/laser/wattz2ks,
 				/obj/effect/spawner/bundle/f13/aer14,


### PR DESCRIPTION
## About The Pull Request
Makes it so the laserbuss no longer drops. Impossible to balance firearm that will always reliably one tap with the skill system, and is just a better Tribeam.

## Pre-Merge Checklist
- [X] You tested this on a local server.
- [X] This code did not runtime during testing.
- [X] You documented all of your changes.

## Changelog
:cl:
del: removes laserbuss from loot table
/:cl: