### PR TITLE
Energy Weapon Skill now scales off perception

### DIFF
--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -279,7 +279,7 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 
 	//Combat
 	var/skill_guns_base = 30
-	var/skill_energy_base = 25
+	var/skill_energy_base = 30
 	var/skill_unarmed_base = 45
 	var/skill_melee_base = 40
 	var/skill_throwing_base = 35

--- a/code/modules/mob/living/living_skills.dm
+++ b/code/modules/mob/living/living_skills.dm
@@ -80,7 +80,7 @@
 	if (SKILL_GUNS == check)
 		return skill_guns + special_a
 	if (SKILL_ENERGY == check)
-		return skill_energy + special_a
+		return skill_energy + special_p
 	if (SKILL_UNARMED == check)
 		return skill_unarmed + round((special_a + special_s)/2)
 	if (SKILL_MELEE == check)
@@ -144,7 +144,7 @@
 /mob/proc/get_skill_all_values()
 	var/list/dat = list()
 	dat = list(list("name" = SKILL_GUNS, "value" = num2text(skill_guns + special_a), "description" = "Applies to ballistic weapons. Controls things like recoil and dispersion. Higher values; tighter firing arcs and slower recoil buildup, Less aim fumble chance."),
-	list("name" = SKILL_ENERGY, "value" = num2text(skill_energy + special_a), "description" = "Applies to energy weapons. Controls things like recoil and dispersion. Higher values slower recoil buildup, Also important for failure to fire chance and aim fumbles."),
+	list("name" = SKILL_ENERGY, "value" = num2text(skill_energy + special_p), "description" = "Applies to energy weapons. Controls things like recoil and dispersion. Higher values slower recoil buildup, Also important for failure to fire chance and aim fumbles."),
 	list("name" = SKILL_UNARMED, "value" = num2text(skill_unarmed + round((special_a + special_s)/2)), "description" = "Hit chance when unarmed, also determines chances to disarm and break out of grabs and the like."),
 	list("name" = SKILL_MELEE, "value" = num2text(skill_melee + round((special_a + special_s)/2)), "description" = "Hit chance when using any melee weapon. Also influnces blocking."),
 	list("name" = SKILL_THROWING, "value" = num2text(skill_throwing + special_a), "description" = "Hit chance for projectiles thrown by your character."),


### PR DESCRIPTION
Fuck it
Since Energy Guns were nerfed
I'm making them scale off Perception
"But nooo it's Fallout 1 and 2 they scaled off-" in Fallout 1 and 2 they were straight upgrades to Regular Guns, I don't care how it worked in Fallout 1 and 2, shut up about Fallout 1 and 2. Here, energy weapons take after New Vegas, being mostly sidegrades of Guns, so they're gonna scale like New Vegas because there's literally no reason for them not to.
I'm also changing the Base Skill to 30 from 25, same as guns, because again, Energy Weapons are Sidegrades and not Upgrades, so it does not make sense from a gameplay perspective for them to be such a huge investment in Skill Points.

## About The Pull Request
<!-- Write here -->

## Pre-Merge Checklist
- [x ] You tested this on a local server.
- [ x] This code did not runtime during testing.
- [x ] You documented all of your changes.

## Changelog
:cl:
tweak: Energy Weapon Skill now scales off perception
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
