### PR TITLE
Moves Pulse Rifle to Unique Loot Drop

### DIFF
--- a/code/game/objects/effects/spawners/f13lootdrop.dm
+++ b/code/game/objects/effects/spawners/f13lootdrop.dm
@@ -767,7 +767,6 @@
 	loot = list(/obj/effect/spawner/bundle/f13/aer9 = 40,
 				/obj/effect/spawner/bundle/f13/wattz2k = 30,
 				/obj/effect/spawner/bundle/f13/plasmapistol = 25,
-				/obj/effect/spawner/bundle/f13/ionrifle = 5
 				)
 
 /obj/effect/spawner/lootdrop/f13/weapon/gun/energy/midhigh //overlaps with midtier
@@ -775,7 +774,6 @@
 	loot = list(/obj/item/gun/energy/laser/aer12 = 20,
 				/obj/effect/spawner/bundle/f13/plasmapistol = 25,
 				/obj/effect/spawner/bundle/f13/wattz2k = 15,
-				/obj/effect/spawner/bundle/f13/ionrifle = 25
 				)
 /obj/effect/spawner/lootdrop/f13/weapon/gun/energy/high
 	name = "high tier energy gun"
@@ -802,6 +800,7 @@
 				/obj/item/gun/energy/laser/wattz2ks,
 				/obj/effect/spawner/bundle/f13/aer14,
 				/obj/item/gun/energy/laser/plasma/pistol/adam
+				/obj/effect/spawner/bundle/f13/ionrifle
 				)
 
 //Ballistic Weapon Spawners

--- a/code/game/objects/effects/spawners/f13lootdrop.dm
+++ b/code/game/objects/effects/spawners/f13lootdrop.dm
@@ -766,14 +766,14 @@
 	name = "mid tier energy gun"
 	loot = list(/obj/effect/spawner/bundle/f13/aer9 = 40,
 				/obj/effect/spawner/bundle/f13/wattz2k = 30,
-				/obj/effect/spawner/bundle/f13/plasmapistol = 25,
+				/obj/effect/spawner/bundle/f13/plasmapistol = 25
 				)
 
 /obj/effect/spawner/lootdrop/f13/weapon/gun/energy/midhigh //overlaps with midtier
 	name = "mid-high tier energy gun"
 	loot = list(/obj/item/gun/energy/laser/aer12 = 20,
 				/obj/effect/spawner/bundle/f13/plasmapistol = 25,
-				/obj/effect/spawner/bundle/f13/wattz2k = 15,
+				/obj/effect/spawner/bundle/f13/wattz2k = 15
 				)
 /obj/effect/spawner/lootdrop/f13/weapon/gun/energy/high
 	name = "high tier energy gun"
@@ -799,7 +799,7 @@
 				/obj/item/gun/energy/laser/plasma/pistol/eve,
 				/obj/item/gun/energy/laser/wattz2ks,
 				/obj/effect/spawner/bundle/f13/aer14,
-				/obj/item/gun/energy/laser/plasma/pistol/adam
+				/obj/item/gun/energy/laser/plasma/pistol/adam,
 				/obj/effect/spawner/bundle/f13/ionrifle
 				)
 


### PR DESCRIPTION
## About The Pull Request
For some reason the YK Pulse Rifle, which has some of if not the best DPS in the game on top of being an ion weapon, is in the mid and midhigh loot pool. This moves it to the unique, where it belongs.

## Pre-Merge Checklist
- [X] You tested this on a local server.
- [X] This code did not runtime during testing.
- [X] You documented all of your changes.
<!-- Tick these after making the PR. -->

## Changelog
:cl:
fix: makes the unique pulse rifle unique
/:cl: