### PR TITLE
Veteran Ranger Gunslinger loadout changes

### DIFF
--- a/code/modules/jobs/job_types/ncr.dm
+++ b/code/modules/jobs/job_types/ncr.dm
@@ -602,8 +602,8 @@ Weapons		Service Rifle, Grease Gun, 9mm pistol, all good.
 	mask = /obj/item/clothing/mask/cigarette/cigar/havana
 	backpack_contents = list(
 		/obj/item/book/granter/trait/gunslinger = 1,
-		/obj/item/gun/ballistic/revolver/revolver45 = 2,
-		/obj/item/ammo_box/c45 = 1,
+		/obj/item/gun/ballistic/revolver/m29/desert_ranger = 2,
+		/obj/item/ammo_box/m44box = 3,
 		/obj/item/lighter = 1,
 		)
 


### PR DESCRIPTION
## About The Pull Request
Gives them .44 Mag instead of .45
Gives them correct ammo.

Still the weakest loadout in my opinion.

## Pre-Merge Checklist
- [* ] You tested this on a local server.
- [ *] This code did not runtime during testing.
- [* ] You documented all of your changes.


## Changelog
:cl:
Veteran Ranger Gunslinger loadout revolver changes
/:cl:

