### PR TITLE
Pulse rifles return

### DIFF
--- a/code/game/objects/effects/spawners/f13lootdrop.dm
+++ b/code/game/objects/effects/spawners/f13lootdrop.dm
@@ -773,7 +773,8 @@
 	name = "mid-high tier energy gun"
 	loot = list(/obj/item/gun/energy/laser/aer12 = 20,
 				/obj/effect/spawner/bundle/f13/plasmapistol = 25,
-				/obj/effect/spawner/bundle/f13/wattz2k = 15
+				/obj/effect/spawner/bundle/f13/wattz2k = 15,
+				/obj/effect/spawner/bundle/f13/ionrifle = 25
 				)
 /obj/effect/spawner/lootdrop/f13/weapon/gun/energy/high
 	name = "high tier energy gun"
@@ -800,8 +801,7 @@
 				/obj/item/gun/energy/laser/plasma/pistol/eve,
 				/obj/item/gun/energy/laser/wattz2ks,
 				/obj/effect/spawner/bundle/f13/aer14,
-				/obj/item/gun/energy/laser/plasma/pistol/adam,
-				/obj/effect/spawner/bundle/f13/ionrifle
+				/obj/item/gun/energy/laser/plasma/pistol/adam
 				)
 
 //Ballistic Weapon Spawners

--- a/code/modules/projectiles/projectile/special/ion.dm
+++ b/code/modules/projectiles/projectile/special/ion.dm
@@ -2,7 +2,7 @@
 	name = "ion bolt"
 	icon_state = "ion"
 	damage = 25
-	armour_penetration = 0.6
+	armour_penetration = 0.3
 	damage_type = BURN
 	flag = "energy"
 	impact_effect_type = /obj/effect/temp_visual/impact_effect/ion


### PR DESCRIPTION
## About The Pull Request
Changing pulse rifles to unique loot spawns made them stop spawning, since there's only two unique spawns on Blythe with four other guns that can spawn in its place. Reverts it back to mid-high with reduced AP, since the draw of the rifle is its EMP effect.

## Pre-Merge Checklist
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
<!-- Tick these after making the PR. -->

## Changelog
:cl:
tweak: Ion rifle back to mid-high tier loot spawns
balance: Ion rifle AP cut in half
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
