### PR TITLE
RCW-14mm destruction

### DIFF
--- a/code/modules/jobs/job_types/legion.dm
+++ b/code/modules/jobs/job_types/legion.dm
@@ -1316,7 +1316,7 @@ Venator  - Zero slots, role built on cloning vet ranger, linear just vastly bett
 	name = "Deadeye"
 	backpack_contents = list(
 		/obj/item/gun/ballistic/rifle/mag/antimateriel = 1,
-			mag_type = /obj/item/ammo_box/magazine/amr = 3,
+		/obj/item/ammo_box/magazine/amr = 3,
 		/obj/item/flashlight/lantern = 1,
 		)
 

--- a/code/modules/jobs/job_types/legion.dm
+++ b/code/modules/jobs/job_types/legion.dm
@@ -1296,8 +1296,8 @@ Venator  - Zero slots, role built on cloning vet ranger, linear just vastly bett
 /datum/outfit/loadout/aupclose
 	name = "Up-Close Killer"
 	backpack_contents = list(
-		/obj/item/ammo_box/magazine/tommygunm45/stick = 2,
-		/obj/item/gun/ballistic/automatic/smg/tommygun = 1,
+		/obj/item/ammo_box/magazine/d12g = 2,
+		/obj/item/gun/ballistic/automatic/shotgun/riot = 1,
 		/obj/item/flashlight/lantern = 1,
 		)
 

--- a/code/modules/jobs/job_types/legion.dm
+++ b/code/modules/jobs/job_types/legion.dm
@@ -1262,8 +1262,9 @@ Venator  - Zero slots, role built on cloning vet ranger, linear just vastly bett
 	exp_requirements = 750
 
 	loadout_options = list(
-		/datum/outfit/loadout/aupclose, // 14mm SMG, ripper
-		/datum/outfit/loadout/adeadeye, // AMR
+		/datum/outfit/loadout/aupclose, // Breacher shotgun.
+		/datum/outfit/loadout/adeadeye, // Venator sniper.
+		/datum/outfit/loadout/hitnrun,  // 10mm smg.
 		)
 
 /datum/outfit/job/CaesarsLegion/Legionnaire/f13venator/post_equip(mob/living/carbon/human/H, visualsOnly = FALSE)
@@ -1300,6 +1301,15 @@ Venator  - Zero slots, role built on cloning vet ranger, linear just vastly bett
 		/obj/item/gun/ballistic/automatic/shotgun/riot = 1,
 		/obj/item/flashlight/lantern = 1,
 		)
+
+/datum/outfit/loadout/hitnrun
+	name = "Hit and Run"
+	backpack_contents = list(
+		/obj/item/ammo_box/magazine/m10mm/smg = 2,
+		/obj/item/gun/ballistic/automatic/smg/smg10mm = 1,
+		/obj/item/flashlight/lantern = 1,
+		)
+
 
 /datum/outfit/loadout/adeadeye
 	name = "Deadeye"

--- a/code/modules/jobs/job_types/legion.dm
+++ b/code/modules/jobs/job_types/legion.dm
@@ -1296,8 +1296,8 @@ Venator  - Zero slots, role built on cloning vet ranger, linear just vastly bett
 /datum/outfit/loadout/aupclose
 	name = "Up-Close Killer"
 	backpack_contents = list(
-		/obj/item/ammo_box/magazine/uzim9mm = 3,
-		/obj/item/gun/ballistic/automatic/smg/mp5 = 1,
+		/obj/item/ammo_box/magazine/tommygunm45/stick = 2,
+		/obj/item/gun/ballistic/automatic/smg/tommygun = 1,
 		/obj/item/flashlight/lantern = 1,
 		)
 

--- a/code/modules/jobs/job_types/legion.dm
+++ b/code/modules/jobs/job_types/legion.dm
@@ -1296,8 +1296,8 @@ Venator  - Zero slots, role built on cloning vet ranger, linear just vastly bett
 /datum/outfit/loadout/aupclose
 	name = "Up-Close Killer"
 	backpack_contents = list(
-		/obj/item/ammo_box/magazine/smg14 = 2,
-		/obj/item/gun/ballistic/automatic/smg/smg14 = 1,
+		/obj/item/ammo_box/magazine/uzim9mm = 3,
+		/obj/item/gun/ballistic/automatic/smg/mp5 = 1,
 		/obj/item/flashlight/lantern = 1,
 		)
 

--- a/code/modules/jobs/job_types/legion.dm
+++ b/code/modules/jobs/job_types/legion.dm
@@ -1308,14 +1308,15 @@ Venator  - Zero slots, role built on cloning vet ranger, linear just vastly bett
 		/obj/item/ammo_box/magazine/m10mm/smg = 2,
 		/obj/item/gun/ballistic/automatic/smg/smg10mm = 1,
 		/obj/item/flashlight/lantern = 1,
+		/obj/item/melee/powered/ripper = 1,
 		)
 
 
 /datum/outfit/loadout/adeadeye
 	name = "Deadeye"
 	backpack_contents = list(
-		/obj/item/gun/ballistic/automatic/marksman/sniper/snipervenator = 1,
-		/obj/item/ammo_box/magazine/w308 = 3,
+		/obj/item/gun/ballistic/rifle/mag/antimateriel = 1,
+			mag_type = /obj/item/ammo_box/magazine/amr = 3,
 		/obj/item/flashlight/lantern = 1,
 		)
 

--- a/code/modules/projectiles/guns/ballistic/automatic.dm
+++ b/code/modules/projectiles/guns/ballistic/automatic.dm
@@ -1709,6 +1709,7 @@
 	icon_state = "venator_sniper"
 	item_state = "venator_sniper"
 
+	zoom_factor = 2.5
 	slowdown = GUN_SLOWDOWN_RIFLE_LIGHT_SEMI
 	force = GUN_MELEE_FORCE_RIFLE_HEAVY
 	weapon_weight = GUN_ONE_HAND_ONLY
@@ -1717,7 +1718,7 @@
 	autofire_shot_delay = GUN_AUTOFIRE_DELAY_FAST
 	burst_shot_delay = GUN_BURSTFIRE_DELAY_FAST
 	burst_size = 1
-	damage_multiplier = GUN_EXTRA_DAMAGE_T1
+	damage_multiplier = GUN_EXTRA_DAMAGE_T3
 	cock_delay = GUN_COCK_RIFLE_BASE
 
 /* * * * * * * * * * *

--- a/code/modules/projectiles/projectile/beams.dm
+++ b/code/modules/projectiles/projectile/beams.dm
@@ -643,7 +643,7 @@
 /obj/item/projectile/beam/laser/rcw/hitscan //RCW
 	name = "rapidfire beam"
 	icon_state = "emitter"
-	damage = 19
+	damage = 15
 	armour_penetration = 0.05
 	hitscan = TRUE
 	muzzle_type = /obj/effect/projectile/muzzle/laser/emitter


### PR DESCRIPTION
Lowers the RCW damage to 15 from 19 and replaced the Legion Assassin 14mm with a Breacher/Riot shotgun instead.

## About The Pull Request
<!-- Write here --> As they title says. From MP5 to Tommygun to Beacher. Along with updating and fixing the venator sniper rifle that was weaker than the normal sniper as it was marked with a lower damage tier than it was supposed to have.

Also adds a new loadout to the Legion assassin with a 10mm smg.

## Pre-Merge Checklist
- [ ] You tested this on a local server.
- [ ] This code did not runtime during testing.
- [ ] You documented all of your changes.
<!-- Tick these after making the PR. -->

## Changelog
:cl:
add: Added new things
add: Added more things
del: Removed old things
tweak: tweaked a few things
balance: rebalanced something
fix: fixed a few things
soundadd: added a new sound thingy
sounddel: removed an old sound thingy
imageadd: added some icons and images
imagedel: deleted some icons and images
spellcheck: fixed a few typos
code: changed some code
refactor: refactored some code
config: changed some config setting
admin: messed with admin stuff
server: something server ops should know
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
