### PR TITLE
Removes Cyro Grenades & Mindshield Implants

### DIFF
--- a/code/modules/research/designs/weapon_designs.dm
+++ b/code/modules/research/designs/weapon_designs.dm
@@ -336,7 +336,7 @@
 	build_path = /obj/item/gun/ballistic/automatic/pistol/deagle
 	category = list("Weapons")
 	departmental_flags = DEPARTMENTAL_FLAG_SECURITY
-	
+
 /datum/design/combatc
 	name = "Combat Carbine"
 	desc = "A .45 carbine."
@@ -567,7 +567,7 @@
 ///////////
 //Grenades/
 ///////////
-
+/*
 /datum/design/large_grenade
 	name = "Large Grenade"
 	desc = "A grenade that affects a larger area and use larger containers."
@@ -607,6 +607,7 @@
 	build_path = /obj/item/grenade/chem_grenade/adv_release
 	category = list("Weapons")
 	departmental_flags = DEPARTMENTAL_FLAG_SECURITY | DEPARTMENTAL_FLAG_MEDICAL | DEPARTMENTAL_FLAG_SCIENCE
+*/
 
 ///////////
 //Shields//

--- a/code/modules/research/techweb/all_nodes.dm
+++ b/code/modules/research/techweb/all_nodes.dm
@@ -396,7 +396,7 @@
 	display_name = "Cryostasis Technology"
 	description = "Smart freezing of objects to preserve them!"
 	prereq_ids = list("adv_engi", "biotech")
-	design_ids = list("splitbeaker", "noreactsyringe", "cryotube", "cryo_Grenade")
+	design_ids = list("splitbeaker", "noreactsyringe", "cryotube")
 	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 2000)
 	export_price = 4000
 	skill_level_needed = REGULAR_CHECK

--- a/code/modules/research/techweb/all_nodes.dm
+++ b/code/modules/research/techweb/all_nodes.dm
@@ -406,7 +406,7 @@
 	display_name = "Subdermal Implants"
 	description = "Electronic implants buried beneath the skin."
 	prereq_ids = list("biotech")
-	design_ids = list("implanter", "implantcase", "implant_chem", "implant_tracking", "implant_auth", "implant_loyal")
+	design_ids = list("implanter", "implantcase", "implant_chem", "implant_tracking")
 	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 2500)
 	export_price = 5000
 	skill_level_needed = REGULAR_CHECK
@@ -548,7 +548,7 @@
 	display_name = "Advanced Weapon Development Technology"
 	description = "Our weapons are breaking the rules of reality by now."
 	prereq_ids = list("adv_engi", "weaponry")
-	design_ids = list("pin_loyalty", "ecp", "bullet_shield")
+	design_ids = list("ecp", "bullet_shield")
 	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 10000)
 	export_price = 5000
 	skill_level_needed = REGULAR_CHECK

--- a/code/modules/research/techweb/nodes/medical_nodes.dm
+++ b/code/modules/research/techweb/nodes/medical_nodes.dm
@@ -16,7 +16,7 @@
 	display_name = "Cryostasis Technology"
 	description = "Smart freezing of objects to preserve them!"
 	prereq_ids = list("adv_engi", "biotech")
-	design_ids = list("splitbeaker", "noreactsyringe", "cryotube", "cryo_Grenade")
+	design_ids = list("splitbeaker", "noreactsyringe", "cryotube")
 	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 2000)
 	alt_skill = SKILL_DOCTOR
 	skill_level_needed = REGULAR_CHECK


### PR DESCRIPTION
## About The Pull Request
Constant chem-mixes abuse. It's fucking agony. Also removes mindshield implants and firing pins; absolutely terrible as all it did was make it so if you got ganked no one could effectively use your guns besides your faction as BOS/Vault.

Tl;dr - these things are HARD abused to the extreme. Mindshield implants screw others over by making guns of a faction with RnD unusable without fully replacing the firing pins (Which I'm unaware of a way to GET regular firing pins anyway) and the cyro grenade custom-payloads allow you to abuse chemicals in code, exploited further by Fermichem.

You CAN still get 1 type of 'custom payload' but it's a C4 so you can't abuse it like throwing a gas grenade or max-cap. I'd have to see if that gets abused but, oddly, it was fine on DR with only one case of abuse which was a chem-related abuse rather than the concept of the item itself. (Funny Elijah gas usage moment.)

## Pre-Merge Checklist
- [ ] You tested this on a local server.
- [ ] This code did not runtime during testing.
- [ ] You documented all of your changes.
<!-- Tick these after making the PR. -->

## Changelog
:cl:
removes: Removes cyro grenades from the designs.
removes: Removes mindshield implants and pins.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
