### PR TITLE
Curling-B-Gone & Big Chew

### DIFF
--- a/code/game/objects/effects/spawners/f13lootdrop.dm
+++ b/code/game/objects/effects/spawners/f13lootdrop.dm
@@ -595,13 +595,13 @@
 		)
 
 /obj/effect/spawner/lootdrop/f13/medical/random_fev
-	name = "random FEV bottle"	//for when you can't decide what is worse
+	name = "2% FEV, 98% Polonium"	//Curling-B-Gone
 	lootcount = 1
 
 	loot = list(
 		/obj/item/reagent_containers/glass/bottle/FEV_solution = 1,
 		/obj/item/reagent_containers/glass/bottle/FEV_solution/two = 1,
-		/obj/item/reagent_containers/glass/bottle/FEV_solution/curling = 1,
+		/obj/item/reagent_containers/glass/bottle/polonium = 98,
 		)
 
 /*	------------------------------------------------

--- a/code/modules/mob/living/simple_animal/hostile/f13/Securitron.dm
+++ b/code/modules/mob/living/simple_animal/hostile/f13/Securitron.dm
@@ -210,7 +210,7 @@
 	flags_1 = PREVENT_CONTENTS_EXPLOSION_1 //cannot self-harm with it's explosion spam
 	sneak_detection_threshold = EXPERT_CHECK
 	sneak_roll_modifier = DIFFICULTY_CHALLENGE
-	projectiletype = /obj/item/projectile/beam/laser/pistol/ultraweak/chewchew
+	projectiletype = /obj/item/projectile/beam/laser/pistol/ultraweak/chew
 	auto_fire_delay = GUN_AUTOFIRE_DELAY_NORMAL
 
 /mob/living/simple_animal/hostile/securitron/sentrybot/chew/bullet_act(obj/item/projectile/Proj)
@@ -220,6 +220,21 @@
 		visible_message(span_danger("\The [src] releases a defensive explosive!"))
 		explosion(get_turf(src),-1,-1,2, flame_range = 4) //perish, mortal - explosion size identical to craftable IED
 	..()
+
+// Big chew-chew
+/mob/living/simple_animal/hostile/securitron/sentrybot/chew/strong //For use as a main bunker boss. Essentially a mildly edited OverSEER port
+	name = "big chew-chew"
+	desc = "An oddly scorched pre-war military robot armed with a deadly gatling laser firing high-penetration experimental lasers and covered in thick, dark blue armor plating, the name Big Chew-Chew scratched onto it's front armour crudely, highlighted by small bits of white paint. There seems to be an odd pack on the monstrosity of a sentrie's back, a chute at the bottom of it - there's the most scorch-marks on the robot here, so it's safe to assume this robot is capable of explosions. Better watch out!"
+	extra_projectiles = 4 //Fires a bit less
+	health = 1500 //more HP than its smaller brother
+	maxHealth = 1500
+	armour_penetration = 0.8 //Punches harder
+	move_to_delay = 3.0 //Is deceptively quick
+	retreat_distance = 0 //Is going to punch you
+	rapid_melee = 2 //Punches faster
+	color = "#00008B" //dark blue
+	emp_flags = list() //no emp instakill for you
+	projectiletype = /obj/item/projectile/beam/laser/pistol/ultraweak/chew/strong
 
 //Raider friendly Sentry bot
 /mob/living/simple_animal/hostile/securitron/sentrybot/nsb

--- a/code/modules/mob/living/simple_animal/hostile/f13/Securitron.dm
+++ b/code/modules/mob/living/simple_animal/hostile/f13/Securitron.dm
@@ -232,7 +232,7 @@
 	move_to_delay = 3.0 //Is deceptively quick
 	retreat_distance = 0 //Is going to punch you
 	rapid_melee = 2 //Punches faster
-	color = "#00008B" //dark blue
+	color = "#3444C8" //dark blue
 	emp_flags = list() //no emp instakill for you
 	projectiletype = /obj/item/projectile/beam/laser/pistol/ultraweak/chew/strong
 

--- a/code/modules/projectiles/projectile/beams.dm
+++ b/code/modules/projectiles/projectile/beams.dm
@@ -311,11 +311,19 @@
 /obj/item/projectile/beam/laser/pistol/ultraweak
 	damage = 15 //quantity over quality
 
-//Chewchews Beam
-/obj/item/projectile/beam/laser/pistol/ultraweak/chewchew
-	damage = 13 //less dam..
-	armour_penetration = 0.75 //..more pen
+//Chews Beam
+/obj/item/projectile/beam/laser/pistol/ultraweak/chew
+	damage = 14 //less dam..
+	armour_penetration = 0.9 //..more pen
 	is_reflectable = FALSE
+
+//Big Chews Beam
+/obj/item/projectile/beam/laser/pistol/ultraweak/chew/strong
+	damage = 18 //it fucks
+	icon_state = "gaussstrong"
+	movement_type = FLYING | UNSTOPPABLE //stopping for nothing except its range
+	pixels_per_second = TILES_TO_PIXELS(15) //slow
+	range = 16
 
 //Alrem's plasmacaster
 /obj/item/projectile/f13plasma/plasmacaster/arlem


### PR DESCRIPTION
## About The Pull Request
![ohno](https://github.com/Afterglow-Ss13/afterglow-ss13/assets/76122712/f84c3ed3-ec22-451f-8eaa-7d1e55b93311)

Removed the Curling 13 bottle from the FEV spawner and made FEV only a 2% chance of spawning- otherwise it will just be Polonium to use at your own discretion. Probably to ghoul yourself or something, iunno I'm not you. 

Also re-adds/ports Big Chew-Chew (the OverSEER) on request of some of the goobers i've asked so he can probably go into that one Tipton RND bunker and smack people, as close to the original big chew as I could get him to be with the time I put into this PR - although this PR doesn't actually put him anywhere. 

Includes a small penetration buff for the normal chew-chews projectiles up to 0.9.

## Pre-Merge Checklist
- [Y] You tested this on a local server.
- [Y] This code did not runtime during testing.
- [Y] You documented all of your changes.

## Changelog
:cl:
add: big chew-chew himself
add: big chew-chews unstoppable unholy piss laser
tweak: FEV spawner (98% polonium, 2% fev)
balance: buffed normal chew-chew beam pen from 0.75 to 0.9
fix: curling obliterated from fev spawner
/:cl: