### PR TITLE
PA Restoration

### DIFF
--- a/code/datums/components/crafting/recipes/recipes_misc.dm
+++ b/code/datums/components/crafting/recipes/recipes_misc.dm
@@ -205,6 +205,20 @@
 	subcategory = CAT_SCAVENGING
 	skill_level = HARD_CHECK
 
+/datum/crafting_recipe/pa_kit
+	name = "Power Armor Servo Repair Kit"
+	time = 5
+	reqs = list(/obj/item/stack/sheet/mineral/titanium = 10,
+				/obj/item/advanced_crafting_components/flux = 1,
+				/obj/item/advanced_crafting_components/conductors = 1,
+				/obj/item/advanced_crafting_components/alloys = 1,
+				/obj/item/stack/crafting/electronicparts = 20)
+	tools = list(TOOL_AWORKBENCH)
+	result = /obj/item/pa_kit
+	category = CAT_CRAFTING
+	subcategory = CAT_SCAVENGING
+	skill_level = EXPERT_CHECK
+
 /datum/crafting_recipe/set_vrboard
 	category = CAT_CRAFTING
 	subcategory = CAT_SCAVENGING

--- a/code/modules/clothing/suits/heavy_armor.dm
+++ b/code/modules/clothing/suits/heavy_armor.dm
@@ -178,28 +178,36 @@
 	custom_price = PRICE_ULTRA_EXPENSIVE
 	strip_delay = 50
 
+/obj/item/clothing/suit/armor/heavy/salvaged_pa/run_block(mob/living/owner, atom/object, damage, attack_text, attack_type, low_velocity, armour_penetration, mob/attacker, def_zone, final_block_chance, list/block_return)
+	if((attack_type == ATTACK_TYPE_PROJECTILE) && (def_zone in protected_zones))
+		if(prob(25) && (low_velocity = 1)) // Low velocity is a variable set on each individual bullet type/caliber. If you want, say, 9mm to not have a chance to deflect anymore, then remove the low_velocity = TRUE tag.
+			block_return[BLOCK_RETURN_REDIRECT_METHOD] = REDIRECT_METHOD_DEFLECT
+			return BLOCK_SHOULD_REDIRECT | BLOCK_REDIRECTED | BLOCK_SUCCESS | BLOCK_PHYSICAL_INTERNAL
+	return ..()
+
 // T-45B
 /obj/item/clothing/suit/armor/heavy/salvaged_pa/t45b
-	name = "salvaged T-45b power armor"
+	name = "salvaged T-45d power armor"
 	desc = "It's a set of early-model T-45 power armor with a custom air conditioning module and stripped out servomotors. Bulky and slow, but almost as good as the real thing."
 	icon_state = "t45b_salvaged"
 	item_state = "t45b_salvaged"
+	armor_tokens = list(ARMOR_MODIFIER_UP_MELEE_T1, ARMOR_MODIFIER_UP_BULLET_T1)
 
 /obj/item/clothing/suit/armor/heavy/salvaged_pa/t45b/raider
 	name = "salvaged raider power armor"
-	desc = "A destroyed T-45b power armor has been brought back to life with the help of a welder and lots of scrap metal."
+	desc = "A destroyed T-45d power armor has been brought back to life with the help of a welder and lots of scrap metal."
 	icon_state = "raider_salvaged"
 	item_state = "raider_salvaged"
 
 /obj/item/clothing/suit/armor/heavy/salvaged_pa/t45b/hotrod
-	name = "salvaged hotrod T-45b power armor"
-	desc = " It's a set of T-45b power armor with a with some of its plating removed. This set has exhaust pipes piped to the pauldrons, flames erupting from them."
+	name = "salvaged hotrod T-45d power armor"
+	desc = " It's a set of T-45d power armor with a with some of its plating removed. This set has exhaust pipes piped to the pauldrons, flames erupting from them."
 	icon_state = "t45hotrod"
 	item_state = "t45hotrod"
 	armor_tokens = list(ARMOR_MODIFIER_UP_FIRE_T3)
 
 /obj/item/clothing/suit/armor/heavy/salvaged_pa/t45b/tribal
-	name = "salvaged tribal T45-b power armor"
+	name = "salvaged tribal T45-d power armor"
 	desc = "A set of salvaged power armor, with certain bits of plating stripped out to retain more freedom of movement. No cooling module, though."
 	icon_state = "tribal_power_armor"
 	item_state = "tribal_power_armor"
@@ -269,7 +277,7 @@
 	icon_state = "legion_heavy"
 	item_state = "legion_heavy"
 	slowdown = ARMOR_SLOWDOWN_HEAVY * ARMOR_SLOWDOWN_LESS_T2 *ARMOR_SLOWDOWN_GLOBAL_MULT
-	armor_tokens = list(ARMOR_MODIFIER_UP_BULLET_T1)
+	armor_tokens = list(ARMOR_MODIFIER_UP_BULLET_T1, ARMOR_MODIFIER_DOWN_LASER_T2)
 
 /obj/item/clothing/suit/armor/heavy/legion/centurion //good all around
 	name = "legion centurion armor"

--- a/code/modules/crafting/items.dm
+++ b/code/modules/crafting/items.dm
@@ -305,3 +305,76 @@ GLOBAL_LIST_INIT(blueprint_fluff, list(
 				/obj/item/advanced_crafting_components/flux,
 				/obj/item/blueprint/research)
 
+/obj/item/pa_kit
+	name = "servo repair kit"
+	desc = "These appear to be used for repairing powerarmor sets..."
+	icon = 'icons/obj/assemblies.dmi'
+	icon_state = "radio-multitool"
+
+/obj/item/pa_kit/attackby(obj/item/W, mob/user, params)
+	. = ..()
+	if(istype(W, /obj/item/gun/ballistic/shotgun))
+		to_chat(usr, "You can't improve [W.name]...")
+		return
+	if(istype(W, /obj/item/gun/ballistic))
+		to_chat(usr, "You can't improve [W.name]...")
+		return
+	if(istype(W, /obj/item/gun/energy))
+		to_chat(usr, "You can't improve [W.name]...")
+		return
+	if(istype(W, /obj/item/clothing/suit/armor/heavy/salvaged_pa/))
+		parmor(W, user)
+		return
+	if(istype(W, /obj/item/clothing/head/helmet/f13/heavy/salvaged_pa))
+		pahat(W, user)
+		return
+	if(istype(W, /obj/item/clothing/suit/armor))
+		to_chat(usr, "You can't improve [W.name]...")
+		return
+
+/obj/item
+	var/tinkered = 0
+	var/untinkerable = FALSE
+
+/obj/item/pa_kit/proc/parmor(obj/item/W, mob/user)
+	var/obj/item/clothing/suit/armor/f13/power_armor/A = W
+	//upgrades basic salvaged PA to full PA. t45b should not be in use anymore, but is covered anyways.
+	//You either need 140 combined or 120 and technophreak to repair t45d.
+	if (((user.skill_value(SKILL_REPAIR) + user.skill_value(SKILL_SCIENCE)) >= 140) || ((user.skill_value(SKILL_REPAIR) + user.skill_value(SKILL_SCIENCE)) >= 120 && (HAS_TRAIT(user, TRAIT_TECHNOPHREAK))))
+		if(istype(A,/obj/item/clothing/suit/armor/heavy/salvaged_pa/t45b))
+			new /obj/item/clothing/suit/armor/power_armor/t45d(user.loc)
+			qdel(A)
+			qdel(src)
+			return
+		if(istype(A,/obj/item/clothing/suit/armor/heavy/salvaged_pa/t45d))
+			new /obj/item/clothing/suit/armor/power_armor/t45d(user.loc)
+			qdel(A)
+			qdel(src)
+			return
+	//You either need 160 combined or 140 and technophreak to repair t51b.
+	if (((user.skill_value(SKILL_REPAIR) + user.skill_value(SKILL_SCIENCE)) >= 160) || ((user.skill_value(SKILL_REPAIR) + user.skill_value(SKILL_SCIENCE)) >= 140 && (HAS_TRAIT(user, TRAIT_TECHNOPHREAK))))
+		if(istype(A,/obj/item/clothing/suit/armor/heavy/salvaged_pa/t51b))
+			new /obj/item/clothing/suit/armor/power_armor/t51b(user.loc)
+			qdel(A)
+			qdel(src)
+			return
+	to_chat(usr, "You have no idea how you would restore [W.name]...")
+
+/obj/item/pa_kit/proc/pahat(obj/item/W, mob/user)
+	var/obj/item/clothing/head/helmet/f13/power_armor/H = W
+	//servo kits are not destroyed on repairing helmets
+	if (((user.skill_value(SKILL_REPAIR) + user.skill_value(SKILL_SCIENCE)) >= 140) || ((user.skill_value(SKILL_REPAIR) + user.skill_value(SKILL_SCIENCE)) >= 120 && (HAS_TRAIT(user, TRAIT_TECHNOPHREAK))))
+		if(istype(H,/obj/item/clothing/head/helmet/f13/heavy/salvaged_pa/t45b))
+			new /obj/item/clothing/head/helmet/f13/power_armor/t45d(user.loc)
+			qdel(H)
+			return
+		if(istype(H,/obj/item/clothing/head/helmet/f13/heavy/salvaged_pa/t45d))
+			new /obj/item/clothing/head/helmet/f13/power_armor/t45d(user.loc)
+			qdel(H)
+			return
+	if (((user.skill_value(SKILL_REPAIR) + user.skill_value(SKILL_SCIENCE)) >= 160) || ((user.skill_value(SKILL_REPAIR) + user.skill_value(SKILL_SCIENCE)) >= 140 && (HAS_TRAIT(user, TRAIT_TECHNOPHREAK))))
+		if(istype(H, /obj/item/clothing/head/helmet/f13/heavy/salvaged_pa/t51b))
+			new /obj/item/clothing/head/helmet/f13/power_armor/t51b(user.loc)
+			qdel(H)
+			return
+	to_chat(usr, "You have no idea how you would restore [W.name]...")


### PR DESCRIPTION
## About The Pull Request
This PR builds off of Rebel's discarded PR on adding Power Armor Restoration. Here is a list of everything this PR does:
-Renames salvaged PA from t45b to t45d
-Allows the crafting of PA servo kits. (80 repair, advanced workbench, rare crafting materials)
-Allows the restoring of salvaged PA with the servo kits. Skill requirements are as follows:
140 total repair + science skill for T45d
160 total repair + science skill for T51b
120 total repair + science skill for T45d with Technophreak trait
140 total repair + science skill for T51b with Technophreak trait
Servo kits are destroyed after restoring armor, but not helmets. 

I have tested the servo kits on a localhost, and it works as intended. I am unable to test the menu crafting for the kits. I have a feeling that this PR will need balance changes in the future. One concept would be requiring the use of adamantine (limited amount per map) to repair the armor. This PR should be seen as a test, rather than the final balanced product.
## Pre-Merge Checklist
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
<!-- Tick these after making the PR. -->

## Changelog
:cl: Dova
-renames T45b salvaged PA to T45d
-allows the crafting of power armor servo kits, which can restore salvaged PA.
/:cl: