### PR TITLE
Mood source nerfs

### DIFF
--- a/code/datums/mood_events/generic_negative_events.dm
+++ b/code/datums/mood_events/generic_negative_events.dm
@@ -195,7 +195,7 @@
 
 /datum/mood_event/revenant_blight/add_effects()
 	description = span_umbra("Just give up, [pick("no one will miss you", "there is nothing you can do to help", "even a clown would be more useful than you", "does it even matter in the end?")]...")
-
+/*
 /datum/mood_event/plushjack
 	description = span_warning("I have butchered a plush recently.")
 	mood_change = -1
@@ -210,7 +210,7 @@
 	description = span_warning("IT BIT ME!! OW!")
 	mood_change = -3
 	timeout = 2 MINUTES
-
+*/
 //Cursed stuff below
 
 /datum/mood_event/emptypred
@@ -296,9 +296,10 @@
 	description = span_boldwarning("I hate when my shoes come untied!")
 	mood_change = -3
 	timeout = 1 MINUTES
-
+/*
 //Necklace
 
 /datum/mood_event/equipped_necklace/cursed_necklace
 	description = span_boldwarning("This necklace gives me a bad feeling...")
 	mood_change = -2
+*/

--- a/code/datums/mood_events/generic_positive_events.dm
+++ b/code/datums/mood_events/generic_positive_events.dm
@@ -144,7 +144,7 @@
 	description = span_nicegreen("Headpats are nice.")
 	mood_change = 1
 	timeout = 5 MINUTES
-
+/*
 /datum/mood_event/hugbox
 	description = span_nicegreen("I hugged a box of hugs recently...")
 	mood_change = list(-2, -1, 0, 1, 2)
@@ -159,7 +159,7 @@
 	description = span_nicegreen("I've played with plushes recently.")
 	mood_change = 3
 	timeout = 10 MINUTES
-
+*/
 /datum/mood_event/breakfast
 	description = span_nicegreen("Nothing like a hearty breakfast to start the day.")
 	mood_change = 2
@@ -225,7 +225,7 @@
 /datum/mood_event/cleared_stomach
 	description = span_nicegreen("Feels nice to get that out of the way!")
 	mood_change = 3
-
+/*
 // RINGS
 /datum/mood_event/equipped_ring
 	description = span_nicegreen("You feel like you have a new purpose in life with your newly equipped silver ring.")
@@ -268,3 +268,4 @@
 /datum/mood_event/equipped_necklace/wolf
 	description = span_nicegreen("The spirit of a wolf dwells within you.")
 	mood_change = 1
+*/

--- a/code/game/objects/items/storage/boxes.dm
+++ b/code/game/objects/items/storage/boxes.dm
@@ -703,7 +703,7 @@ obj/item/storage/box/stingbangs
 	user.DelayNextAction(CLICK_CD_MELEE)
 	playsound(src, "rustle", 50, 1, -5)
 	user.visible_message(span_notice("[user] hugs \the [src]."),span_notice("You hug \the [src]."))
-	SEND_SIGNAL(user, COMSIG_ADD_MOOD_EVENT,"hugbox", /datum/mood_event/hugbox)
+//	SEND_SIGNAL(user, COMSIG_ADD_MOOD_EVENT,"hugbox", /datum/mood_event/hugbox)
 
 
 //////

--- a/code/modules/clothing/gloves/ring.dm
+++ b/code/modules/clothing/gloves/ring.dm
@@ -10,8 +10,8 @@
 	attack_verb = list("proposed")
 	transfer_prints = TRUE
 	strip_delay = 40
-	var/mood_event_on_equip = /datum/mood_event/equipped_ring/gold
-
+//	var/mood_event_on_equip = /datum/mood_event/equipped_ring/gold
+/*
 /obj/item/clothing/gloves/ring/equipped(mob/user, slot)
 	. = ..()
 	if (slot == SLOT_GLOVES && istype(user))
@@ -22,7 +22,7 @@
 /obj/item/clothing/gloves/ring/dropped(mob/user)
 	. = ..()
 	SEND_SIGNAL(user, COMSIG_CLEAR_MOOD_EVENT, "ringbuff")
-
+*/
 
 /obj/item/clothing/gloves/ring/suicide_act(mob/living/carbon/user)
 	user.visible_message(span_suicide("\[user] is putting the [src] in [user.p_their()] mouth! It looks like [user] is trying to choke on the [src]!"))
@@ -33,7 +33,7 @@
 	desc = "An expensive ring, studded with a diamond. Cultures have used these rings in courtship for a millenia."
 	icon_state = "ringdiamond"
 	item_state = "dring"
-	mood_event_on_equip = /datum/mood_event/equipped_ring/diamond
+//	mood_event_on_equip = /datum/mood_event/equipped_ring/diamond
 
 /obj/item/clothing/gloves/ring/diamond/attack_self(mob/user)
 	user.visible_message(span_warning("\The [user] gets down on one knee, presenting \the [src]."),span_warning("You get down on one knee, presenting \the [src]."))
@@ -43,18 +43,18 @@
 	desc = "A tiny silver ring, sized to wrap around a finger."
 	icon_state = "ringsilver"
 	item_state = "sring"
-	mood_event_on_equip = /datum/mood_event/equipped_ring
+//	mood_event_on_equip = /datum/mood_event/equipped_ring
 
 /obj/item/clothing/gloves/ring/plasma
 	name = "plasma ring"
 	desc = "This ring is stylized to have an ornate sun, with a sample of phoron swirling around inside."
 	icon_state = "ringplasma"
 	item_state = "pring"
-	mood_event_on_equip = /datum/mood_event/equipped_ring/plasma
+//	mood_event_on_equip = /datum/mood_event/equipped_ring/plasma
 
 /obj/item/clothing/gloves/ring/bluespace
 	name = "bluespace ring"
 	desc = "This ring is stylized to have an ornate sun, with a small sample of a bluespace crystal shining inside."
 	icon_state = "ringbluespace"
 	item_state = "bring"
-	mood_event_on_equip = /datum/mood_event/equipped_ring/bluespace
+//	mood_event_on_equip = /datum/mood_event/equipped_ring/bluespace

--- a/code/modules/clothing/neck/_neck.dm
+++ b/code/modules/clothing/neck/_neck.dm
@@ -5,8 +5,8 @@
 	slot_flags = ITEM_SLOT_NECK
 	strip_delay = 40
 	equip_delay_other = 40
-	var/mood_event_on_equip = /datum/mood_event/equipped_necklace/any
-
+//	var/mood_event_on_equip = /datum/mood_event/equipped_necklace/any
+/*
 /obj/item/clothing/neck/equipped(mob/user, slot)
 	. = ..()
 	if (slot == SLOT_NECK && istype(user))
@@ -17,7 +17,7 @@
 /obj/item/clothing/neck/dropped(mob/user)
 	. = ..()
 	SEND_SIGNAL(user, COMSIG_CLEAR_MOOD_EVENT, "necklacebuff")
-
+*/
 /obj/item/clothing/neck/worn_overlays(isinhands = FALSE, icon_file, used_state, style_flags = NONE)
 	. = ..()
 	if(!isinhands)
@@ -368,35 +368,35 @@ obj/item/clothing/neck/neckerchief
 	desc = "A necklace with a spooky aura about it."
 	icon_state = "cursed_necklace"
 	item_state = "cursed_necklace"
-	mood_event_on_equip = /datum/mood_event/equipped_necklace/cursed_necklace
+//	mood_event_on_equip = /datum/mood_event/equipped_necklace/cursed_necklace
 
 /obj/item/clothing/neck/sapphirecollar
 	name = "Sapphire Collar"
 	desc = "A gold and platinum collar, with a embedded sapphire gem."
 	icon_state = "sapphirecollar"
 	item_state = "sapphirecollar"
-	mood_event_on_equip = /datum/mood_event/equipped_necklace/sapphire
+//	mood_event_on_equip = /datum/mood_event/equipped_necklace/sapphire
 
 /obj/item/clothing/neck/rubycollar
 	name = "Ruby Collar"
 	desc = "A gold and platinum collar, with a embedded ruby gem."
 	icon_state = "rubycollar"
 	item_state = "rubycollar"
-	mood_event_on_equip = /datum/mood_event/equipped_necklace/ruby
+//	mood_event_on_equip = /datum/mood_event/equipped_necklace/ruby
 
 /obj/item/clothing/neck/heartcollar
 	name = "Heart Collar"
 	desc = "This collar appears to have a heart shaped pin on the front."
 	icon_state = "heartcollar"
 	item_state = "heartcollar"
-	mood_event_on_equip = /datum/mood_event/equipped_necklace/heart
+//	mood_event_on_equip = /datum/mood_event/equipped_necklace/heart
 
 /obj/item/clothing/neck/wolfpendant
 	name = "Wolf Pendant"
 	desc = "It is a black pendant with what looks like a wolf head with tentacles coming out from the sides."
 	icon_state = "wolfpendant"
 	item_state = "wolfpendant"
-	mood_event_on_equip = /datum/mood_event/equipped_necklace/wolf
+//	mood_event_on_equip = /datum/mood_event/equipped_necklace/wolf
 
 /obj/item/clothing/neck/spikecollar
 	name = "Spiked Collar"


### PR DESCRIPTION
## About The Pull Request
Removes a lot of sources of positive mood that are either too easy or too irrelevant for roleplay or mechanical purposes. This includes rings, necklaces, plushes and hugboxes. All of these items should still exist, they just won't provide mood buffs. Now that mood is more of an important mechanic with Charisma playing a factor, it is important that there are not easy ways to powergame the system.

I will test the PR when I get home and make sure none of the items are broken/cause errors. Just wanted to see if it checks well in this draft.

## Pre-Merge Checklist
- [ ] You tested this on a local server.
- [ ] This code did not runtime during testing.
- [ ] You documented all of your changes.
<!-- Tick these after making the PR. -->

## Changelog
:cl: Dova
-Removes moodbuffs from various sources (rings, necklaces, hugboxes, plushies)
/:cl: