### PR TITLE
High spawner rebalance

### DIFF
--- a/code/game/objects/effects/spawners/f13lootdrop.dm
+++ b/code/game/objects/effects/spawners/f13lootdrop.dm
@@ -788,8 +788,9 @@
 
 /obj/effect/spawner/lootdrop/f13/weapon/gun/energy/superhigh
 	name = "superhigh tier energy gun"
-	loot = list(/obj/effect/spawner/bundle/f13/multiplas,
-				/obj/item/gun/energy/laser/plasma/pistol/alien
+	loot = list(/obj/item/gun/energy/laser/plasma/caster/balanced,
+				/obj/item/minigunpack,
+				/obj/item/gun/energy/laser/aer14
 				)
 
 /obj/effect/spawner/lootdrop/f13/weapon/gun/energy/unique

--- a/code/game/objects/effects/spawners/f13lootdrop.dm
+++ b/code/game/objects/effects/spawners/f13lootdrop.dm
@@ -782,8 +782,7 @@
 				/obj/effect/spawner/bundle/f13/tribeam = 20,
 				/obj/effect/spawner/bundle/f13/rcw = 20,
 				/obj/effect/spawner/bundle/f13/wattz2kext = 10, //Now a high tier gun.
-				/obj/effect/spawner/bundle/f13/plasmaglock = 20,
-				/obj/item/minigunpack = 20
+				/obj/effect/spawner/bundle/f13/plasmaglock = 20
 				)
 
 /obj/effect/spawner/lootdrop/f13/weapon/gun/energy/superhigh
@@ -802,7 +801,8 @@
 				/obj/item/gun/energy/laser/plasma/pistol/eve,
 				/obj/item/gun/energy/laser/wattz2ks,
 				/obj/effect/spawner/bundle/f13/aer14,
-				/obj/item/gun/energy/laser/plasma/pistol/adam
+				/obj/item/gun/energy/laser/plasma/pistol/adam,
+				/obj/item/minigunpack
 				)
 
 //Ballistic Weapon Spawners


### PR DESCRIPTION
## About The Pull Request
<!-- Write here -->
the superhigh laser spawner now chooses between ( AER14 / LASER MINIGUN / PLASMA CASTER"BALANCED" ) 


instead of ( ALIEN PISTOL / PLASMA SHOTGUN )

why?
both those guns were apparently quite wackily good, making the spawner non-usable
these guns are somewhat more balanced, and should be safe to put down in some hard dungeons!
## Pre-Merge Checklist
- [ ] You tested this on a local server.
- [ ] This code did not runtime during testing.
- [x] You documented all of your changes.
<!-- Tick these after making the PR. -->

## Changelog
:cl:
tweak: Remade Superhigh energy spawners
tweak: moved the energy gatling laser to unique from high
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
