### PR TITLE
Small QoL fixes

### DIFF
--- a/code/datums/components/crafting/recipes/recipes_forge.dm
+++ b/code/datums/components/crafting/recipes/recipes_forge.dm
@@ -169,7 +169,7 @@
 /datum/crafting_recipe/melee/forged/bayonet
 	name = "Bayonet Knife"
 	result = /obj/item/melee/onehanded/knife/bayonet
-	time = 300
+	time = 100
 	reqs = list(
 		/obj/item/stack/sheet/metal = 6,
 		/obj/item/blacksmith/swordhandle = 1,

--- a/code/datums/components/crafting/recipes/recipes_medicine.dm
+++ b/code/datums/components/crafting/recipes/recipes_medicine.dm
@@ -39,10 +39,20 @@
 
 /datum/crafting_recipe/regular_gauze
 	name = "Regular Gauze"
-	result = /obj/item/stack/medical/gauze
-	time = 50
+	result = /obj/item/stack/medical/gauze/one
+	time = 10
 	reqs = list(/obj/item/stack/medical/gauze/improvised = 1,
 				/datum/reagent/abraxo_cleaner = 5)
+	category = CAT_MEDICAL
+	skill_needed = SKILL_SCIENCE
+	skill_level = EASY_CHECK
+
+/datum/crafting_recipe/regular_gauze10
+	name = "Regular Gauze (x10)"
+	result = /obj/item/stack/medical/gauze
+	time = 50
+	reqs = list(/obj/item/stack/medical/gauze/improvised = 10,
+				/datum/reagent/abraxo_cleaner = 50)
 	category = CAT_MEDICAL
 	skill_needed = SKILL_SCIENCE
 	skill_level = EASY_CHECK
@@ -50,9 +60,20 @@
 /datum/crafting_recipe/upgraded_gauze
 	name = "Improved Gauze"
 	result = /obj/item/stack/medical/gauze/adv/one
-	time = 50
+	time = 10
 	reqs = list(/obj/item/stack/medical/gauze = 1,
 				/datum/reagent/abraxo_cleaner/sterilizine = 10)
+	category = CAT_MEDICAL
+	blacklist = list(/obj/item/stack/medical/gauze/improvised)
+	skill_needed = SKILL_SCIENCE
+	skill_level = REGULAR_CHECK
+
+/datum/crafting_recipe/upgraded_gauze10
+	name = "Improved Gauze (x10)"
+	result = /obj/item/stack/medical/gauze/adv
+	time = 50
+	reqs = list(/obj/item/stack/medical/gauze = 10,
+				/datum/reagent/abraxo_cleaner/sterilizine = 100)
 	category = CAT_MEDICAL
 	blacklist = list(/obj/item/stack/medical/gauze/improvised)
 	skill_needed = SKILL_SCIENCE

--- a/code/game/objects/items/stacks/medical.dm
+++ b/code/game/objects/items/stacks/medical.dm
@@ -496,6 +496,10 @@
 	user.visible_message(span_suicide("[user] begins tightening \the [src] around [user.p_their()] neck! It looks like [user.p_they()] forgot how to use medical supplies!"))
 	return OXYLOSS
 
+/obj/item/stack/medical/gauze/one
+	amount = 1
+
+
 /// Low tier bandage
 /obj/item/stack/medical/gauze/improvised
 	name = "improvised bandages"

--- a/code/modules/hydroponics/grown/corn.dm
+++ b/code/modules/hydroponics/grown/corn.dm
@@ -8,7 +8,7 @@
 	product = /obj/item/reagent_containers/food/snacks/grown/corn
 	maturation = 8
 	potency = 20
-	instability = 50 // Corn used to be wheatgrass, but through generations of selective cultivation...
+	instability = 30 // Corn used to be wheatgrass, but through generations of selective cultivation...
 	growthstages = 3
 	growing_icon = 'icons/obj/hydroponics/growing_vegetables.dmi'
 	icon_grow = "corn-grow" // Uses one growth icons set for all the subtypes

--- a/code/modules/surgery/tools.dm
+++ b/code/modules/surgery/tools.dm
@@ -151,6 +151,7 @@
 	icon = 'icons/obj/surgery.dmi'
 	icon_state = "surgicaldrill_a"
 	hitsound = 'sound/items/welder.ogg'
+	w_class = WEIGHT_CLASS_TINY
 	light_system = MOVABLE_LIGHT
 	light_range = 1
 


### PR DESCRIPTION
## About The Pull Request
Just put in a couple of Small QoL fixes for things that were bugging me and other players.
1)Reduced starting Corn instability from 50 to 30. 50 instability was pretty much unmanageable for anyone without dedicated agriculture machines.
2)Reduced the crafting time of Sterilized Bandages from 50 to 10, and added a x10 version. Spending 50 ticks for one (1) sterilized bandage was just too much for what you got.
3)Reduced the crafting time of Bayonets from 300 to 100, bringing it in line with the Survival Knife.
4)Changes the size of the searing tool to tiny so it can actually fit in the surgical belt. Before this, since the drill function is very situational, it was basically a worse cautery.

## Pre-Merge Checklist
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
<!-- Tick these after making the PR. -->

## Changelog
:cl:
tweak: Corn now less unstable
tweak: Sterilized bandages don't take three years to craft anymore
tweak: Same for Bayonets
tweak:Changes size of Searing Tool to tiny so it can actually fit in the surgical supply belt
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
