### PR TITLE
Adds salt to the NCR base in Blythe

### DIFF
--- a/_maps/map_files/Blythe-small/blythe-surface.dmm
+++ b/_maps/map_files/Blythe-small/blythe-surface.dmm
@@ -20031,6 +20031,11 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/white/whitesolid,
 /area/f13/building/mall)
+"jxZ" = (
+/obj/structure/table/wood,
+/obj/item/reagent_containers/food/condiment/peppermill,
+/turf/open/floor/plasteel/f13/stone,
+/area/f13/ncr)
 "jyn" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "#363636"
@@ -32575,6 +32580,11 @@
 	icon_state = "dirt"
 	},
 /area/f13/wasteland)
+"pqh" = (
+/obj/structure/table/wood,
+/obj/item/reagent_containers/food/condiment/saltshaker,
+/turf/open/floor/plasteel/f13/stone,
+/area/f13/ncr)
 "pql" = (
 /obj/structure/bonfire/prelit{
 	pixel_y = -10
@@ -58206,7 +58216,7 @@ ydr
 idD
 wGh
 sIz
-uYt
+pqh
 idD
 tNJ
 oRv
@@ -58411,7 +58421,7 @@ kGL
 jKL
 dAi
 tNJ
-uYt
+pqh
 tNJ
 dPQ
 aGe
@@ -58613,7 +58623,7 @@ kGL
 osl
 dAi
 tNJ
-uYt
+jxZ
 tNJ
 jfk
 aGe
@@ -59014,7 +59024,7 @@ ibu
 idD
 tNJ
 jxd
-uYt
+jxZ
 piA
 wGh
 eaO


### PR DESCRIPTION
## About The Pull Request
NCR previously had no salt, locking it out of some recipes. This adds a couple of salt shakers to their base to rectify this.

## Pre-Merge Checklist
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
<!-- Tick these after making the PR. -->

## Changelog
:cl:
add: Salt to the NCR Base
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
