### PR TITLE
Heavy trooper starting gear redux

### DIFF
--- a/code/modules/jobs/job_types/ncr.dm
+++ b/code/modules/jobs/job_types/ncr.dm
@@ -803,7 +803,6 @@ Weapons		Service Rifle, Grease Gun, 9mm pistol, all good.
 	loadout_options = list(
 		/datum/outfit/loadout/shockht,	// R84
 		/datum/outfit/loadout/supportht, // minigun
-		/datum/outfit/loadout/meleeht //Supersledge
 		)
 
 /datum/outfit/job/ncr/f13heavytrooper/post_equip(mob/living/carbon/human/H, visualsOnly = FALSE)
@@ -842,15 +841,6 @@ Weapons		Service Rifle, Grease Gun, 9mm pistol, all good.
 	name = "Support Heavy Trooper"
 	backpack_contents = list(
 		/obj/item/minigunpackbal5mm = 1,
-		/obj/item/melee/onehanded/knife/bowie = 1,
-		)
-
-/datum/outfit/loadout/meleeht
-	name = "Melee Heavy Trooper"
-	backpack_contents = list(
-		/obj/item/twohanded/sledgehammer/supersledge = 1,
-		/obj/item/gun/ballistic/revolver/hunting = 1,
-		/obj/item/ammo_box/c4570 = 2,
 		/obj/item/melee/onehanded/knife/bowie = 1,
 		)
 

--- a/code/modules/jobs/job_types/ncr.dm
+++ b/code/modules/jobs/job_types/ncr.dm
@@ -801,8 +801,9 @@ Weapons		Service Rifle, Grease Gun, 9mm pistol, all good.
 	exp_requirements = 375
 
 	loadout_options = list(
-		/datum/outfit/loadout/shockht,	// Minigun
-		/datum/outfit/loadout/supportht, // R84
+		/datum/outfit/loadout/shockht,	// R84
+		/datum/outfit/loadout/supportht, // minigun
+		/datum/outfit/loadout/meleeht //Supersledge
 		)
 
 /datum/outfit/job/ncr/f13heavytrooper/post_equip(mob/living/carbon/human/H, visualsOnly = FALSE)
@@ -840,13 +841,18 @@ Weapons		Service Rifle, Grease Gun, 9mm pistol, all good.
 /datum/outfit/loadout/supportht
 	name = "Support Heavy Trooper"
 	backpack_contents = list(
-		/obj/item/gun/ballistic/revolver/grenadelauncher = 1,
-		/obj/item/ammo_box/a40mm = 1,
+		/obj/item/minigunpackbal5mm = 1,
+		/obj/item/melee/onehanded/knife/bowie = 1,
+		)
+
+/datum/outfit/loadout/meleeht
+	name = "Melee Heavy Trooper"
+	backpack_contents = list(
+		/obj/item/twohanded/sledgehammer/supersledge = 1,
 		/obj/item/gun/ballistic/revolver/hunting = 1,
 		/obj/item/ammo_box/c4570 = 2,
 		/obj/item/melee/onehanded/knife/bowie = 1,
 		)
-
 
 // COMBAT ENGINEER
 

--- a/code/modules/jobs/job_types/ncr.dm
+++ b/code/modules/jobs/job_types/ncr.dm
@@ -840,8 +840,10 @@ Weapons		Service Rifle, Grease Gun, 9mm pistol, all good.
 /datum/outfit/loadout/supportht
 	name = "Support Heavy Trooper"
 	backpack_contents = list(
-		/obj/item/m2flamethrowertank = 1,
-		/obj/item/ammo_box/jerrycan = 1,
+		/obj/item/gun/ballistic/revolver/grenadelauncher = 1,
+		/obj/item/ammo_box/a40mm = 1,
+		/obj/item/gun/ballistic/revolver/hunting = 1,
+		/obj/item/ammo_box/c4570 = 2,
 		/obj/item/melee/onehanded/knife/bowie = 1,
 		)
 


### PR DESCRIPTION
## About The Pull Request
<!-- Write here -->
this PR does one thing
it replaces the Flamethrower (which barely worked) with the now Nerfed minigun

Why?
nobody uses the flamethrower kit, due to it being mostly non-functional
## Pre-Merge Checklist
- [ ] You tested this on a local server.
- [ ] This code did not runtime during testing.
- [x] You documented all of your changes.
<!-- Tick these after making the PR. -->

## Changelog
:cl:
tweak: Replaced the HT flamethrower with a minigun
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
