### PR TITLE
Various Fixes & Edits (PA, SPA, Head Scribe, Etc)

### DIFF
--- a/code/__DEFINES/armor.dm
+++ b/code/__DEFINES/armor.dm
@@ -64,7 +64,7 @@
 		"linebullet" = 15, \
 		"linelaser" = 15, \
 		"energy" = 0, \
-		"bomb" = 0, \
+		"bomb" = 15, \
 		"bio" = 10, \
 		"rad" = 10, \
 		"fire" = 10, \
@@ -85,7 +85,7 @@
 		"linebullet" = 35, \
 		"linelaser" = 35, \
 		"energy" = 5, \
-		"bomb" = 10, \
+		"bomb" = 30, \
 		"bio" = 25, \
 		"rad" = 25, \
 		"fire" = 25, \
@@ -106,7 +106,7 @@
 		"linebullet" = 50, \
 		"linelaser" = 50, \
 		"energy" = 10, \
-		"bomb" = 25, \
+		"bomb" = 50, \
 		"bio" = 25, \
 		"rad" = 25, \
 		"fire" = 35, \
@@ -142,12 +142,12 @@
  * Great defense
  * Lots of DT
  *
- * +80 effective HP
- * +20 laser HP
+ * +90 effective HP
+ * +10 laser HP
  * * * * * * * * * * * */
 #define ARMOR_VALUE_PA list(\
-		"linemelee" = 80, \
-		"linebullet" = 80, \
+		"linemelee" = 90, \
+		"linebullet" = 90, \
 		"linelaser" = 100, \
 		"energy" = 40, \
 		"bomb" = 70, \

--- a/code/modules/clothing/head/f13_helmets.dm
+++ b/code/modules/clothing/head/f13_helmets.dm
@@ -974,7 +974,6 @@
 	icon_state = "t45dhelmet0"
 	item_state = "t45dhelmet0"
 	actions_types = list(/datum/action/item_action/toggle_helmet_light)
-	armor_tokens = list(ARMOR_MODIFIER_UP_MELEE_T1, ARMOR_MODIFIER_UP_BULLET_T1)
 	salvaged_type = /obj/item/clothing/head/helmet/f13/heavy/salvaged_pa/t45d
 
 /obj/item/clothing/head/helmet/f13/power_armor/t45d/update_icon_state()

--- a/code/modules/clothing/head/f13_helmets.dm
+++ b/code/modules/clothing/head/f13_helmets.dm
@@ -781,7 +781,7 @@
 	desc = "This power armor helmet is so decrepit and battle-worn that it have lost most of its capability to protect the wearer from harm."
 	icon_state = "t45hotrod_helm"
 	item_state = "t45hotrod_helm"
-	armor_tokens = list(ARMOR_MODIFIER_UP_FIRE_T3)
+	armor_tokens = list(ARMOR_MODIFIER_UP_FIRE_T2)
 
 /obj/item/clothing/head/helmet/f13/heavy/salvaged_pa/t45b/tribal
 	name = "tribal t-45d headdress"
@@ -798,7 +798,6 @@
 	desc = "It's a salvaged T-45d power armor helmet."
 	icon_state = "t45dhelmet0"
 	item_state = "t45dhelmet0"
-	armor_tokens = list(ARMOR_MODIFIER_UP_MELEE_T1, ARMOR_MODIFIER_UP_BULLET_T1)
 
 // T-51B
 /obj/item/clothing/head/helmet/f13/heavy/salvaged_pa/t51b

--- a/code/modules/clothing/suits/heavy_armor.dm
+++ b/code/modules/clothing/suits/heavy_armor.dm
@@ -184,7 +184,6 @@
 	desc = "It's a set of early-model T-45 power armor with a custom air conditioning module and stripped out servomotors. Bulky and slow, but almost as good as the real thing."
 	icon_state = "t45b_salvaged"
 	item_state = "t45b_salvaged"
-	armor_tokens = list(ARMOR_MODIFIER_UP_MELEE_T1, ARMOR_MODIFIER_UP_BULLET_T1)
 
 /obj/item/clothing/suit/armor/heavy/salvaged_pa/t45b/raider
 	name = "salvaged raider power armor"
@@ -197,7 +196,7 @@
 	desc = " It's a set of T-45d power armor with a with some of its plating removed. This set has exhaust pipes piped to the pauldrons, flames erupting from them."
 	icon_state = "t45hotrod"
 	item_state = "t45hotrod"
-	armor_tokens = list(ARMOR_MODIFIER_UP_FIRE_T3)
+	armor_tokens = list(ARMOR_MODIFIER_UP_FIRE_T2, ARMOR_MODIFIER_DOWN_BULLET_T1, ARMOR_MODIFIER_DOWN_MELEE_T1)
 
 /obj/item/clothing/suit/armor/heavy/salvaged_pa/t45b/tribal
 	name = "salvaged tribal T45-d power armor"
@@ -212,7 +211,6 @@
 	desc = "T-45d power armor with servomotors and all valuable components stripped out of it."
 	icon_state = "t45d_salvaged"
 	item_state = "t45d_salvaged"
-	armor_tokens = list(ARMOR_MODIFIER_UP_MELEE_T1, ARMOR_MODIFIER_UP_BULLET_T1)
 
 // T-51B
 /obj/item/clothing/suit/armor/heavy/salvaged_pa/t51b

--- a/code/modules/clothing/suits/light_armor.dm
+++ b/code/modules/clothing/suits/light_armor.dm
@@ -622,8 +622,8 @@
 	desc = "A heavy-duty coat and chestrig fitted with tons of pockets. Ballistic weave and ceramic inserts are included to substantially increase Field Scribe survival rates."
 	icon_state = "scribecoat"
 	item_state = "scribecoat"
-	armor_tokens = list(ARMOR_MODIFIER_UP_LASER_T1, ARMOR_MODIFIER_UP_BULLET_T1, ARMOR_MODIFIER_UP_ENV_T2, ARMOR_MODIFIER_UP_DT_T1)
-	slowdown = ARMOR_SLOWDOWN_LIGHT * ARMOR_SLOWDOWN_GLOBAL_MULT
+	armor_tokens = list(ARMOR_MODIFIER_UP_LASER_T1, ARMOR_MODIFIER_UP_MELEE_T1, ARMOR_MODIFIER_UP_BULLET_T1, ARMOR_MODIFIER_UP_ENV_T2, ARMOR_MODIFIER_UP_DT_T1)
+	slowdown = ARMOR_SLOWDOWN_LIGHT * ARMOR_SLOWDOWN_MORE_T2 * ARMOR_SLOWDOWN_GLOBAL_MULT
 
 /obj/item/clothing/suit/armor/light/duster/bos/scribe/field_coat/lancer
 	name = "Lancer's Pilot Jacket"

--- a/code/modules/clothing/suits/light_armor.dm
+++ b/code/modules/clothing/suits/light_armor.dm
@@ -632,7 +632,6 @@
 	item_state = "lancer_jacket"
 	armor_tokens = list(ARMOR_MODIFIER_UP_LASER_T1, ARMOR_MODIFIER_UP_ENV_T2)
 
-
 /obj/item/clothing/suit/armor/light/duster/bos/scribe/elder
 	name = "Brotherhood Elder's robe"
 	desc = "A blue cloth robe with some scarlet red parts, traditionally worn by the Brotherhood of Steel Elder."

--- a/code/modules/clothing/suits/power_armor.dm
+++ b/code/modules/clothing/suits/power_armor.dm
@@ -325,8 +325,7 @@ Most bullets literally DO NOT have fucking armor pen, so it deflects nearly all 
 /obj/item/clothing/suit/armor/power_armor/t45b
 	name = "T-45d power armor"
 	desc = "Originally developed and manufactured for the United States Army by American defense contractor West Tek, the T-45d power armor was the first version of power armor to be successfully deployed in battle."
-	salvaged_type = /obj/item/clothing/suit/armor/heavy/salvaged_pa/t45b
-	armor_tokens = list(ARMOR_MODIFIER_DOWN_LASER_T1, ARMOR_MODIFIER_UP_MELEE_T1)
+	salvaged_type = /obj/item/clothing/suit/armor/heavy/salvaged_pa/t45d
 
 /obj/item/clothing/suit/armor/power_armor/t45d
 	name = "T-45d power armor"
@@ -334,7 +333,6 @@ Most bullets literally DO NOT have fucking armor pen, so it deflects nearly all 
 	icon_state = "t45dpowerarmor"
 	item_state = "t45dpowerarmor"
 	salvaged_type = /obj/item/clothing/suit/armor/heavy/salvaged_pa/t45d
-	armor_tokens = list(ARMOR_MODIFIER_DOWN_LASER_T1, ARMOR_MODIFIER_UP_MELEE_T1)
 
 /obj/item/clothing/suit/armor/power_armor/t51b
 	name = "T-51b power armor"

--- a/code/modules/jobs/job_types/bos.dm
+++ b/code/modules/jobs/job_types/bos.dm
@@ -297,8 +297,7 @@ Head Scribe
 	id = 			/obj/item/card/id/dogtag
 	backpack_contents = list(
 		/obj/item/melee/onehanded/knife/survival = 1,
-		/obj/item/reagent_containers/hypospray/medipen/stimpak = 3,
-		/obj/item/kit_spawner/bos/scientist = 1
+		/obj/item/reagent_containers/hypospray/medipen/stimpak = 3
 		)
 
 /datum/outfit/loadout/hsword
@@ -307,6 +306,8 @@ Head Scribe
 		/obj/item/gun/energy/laser/plasma/glock = 1,
 		/obj/item/stock_parts/cell/ammo/ec = 2,
 		/obj/item/book/granter/crafting_recipe/blueprint/wattz2k = 1,
+		/obj/item/book/granter/crafting_recipe/blueprint/aer9 = 1,
+		/obj/item/book/granter/crafting_recipe/blueprint/aep7 = 1,
 		)
 
 /datum/outfit/loadout/hshield
@@ -314,8 +315,7 @@ Head Scribe
 	backpack_contents = list(
 		/obj/item/gun/energy/laser/plasma/glock = 1,
 		/obj/item/stock_parts/cell/ammo/ec = 2,
-		/obj/item/clothing/suit/armor/heavy/salvaged_pa/t45b = 1,
-		/obj/item/clothing/head/helmet/f13/heavy/salvaged_pa/t45b = 1,
+		/obj/item/construction/rcd/combat = 1,
 		)
 
 /datum/outfit/loadout/hquill
@@ -686,6 +686,7 @@ Senior Scribe
 	name = "Order of the Sword"
 	backpack_contents = list(
 		/obj/item/book/granter/crafting_recipe/blueprint/aer9 = 1,
+		/obj/item/book/granter/crafting_recipe/blueprint/aep7 = 1,
 		/obj/item/gun/energy/laser/pistol=1,
 		/obj/item/stock_parts/cell/ammo/ec=2,
 		)

--- a/modular_citadel/code/modules/client/loadout/suit.dm
+++ b/modular_citadel/code/modules/client/loadout/suit.dm
@@ -141,7 +141,7 @@
 
 /datum/gear/suit/fieldscribe/coat
 	name = "Fieldscribe coat"
-	path = /obj/item/clothing/suit/toggle/labcoat/scribecoat
+	path = /obj/item/clothing/suit/armor/light/duster/bos/scribe/field_coat
 
 /datum/gear/suit/town
 	name = "Town Trenchcoat"


### PR DESCRIPTION
## About The Pull Request
List of what this PR does:
- Adjusts Power Armor protection up by 10 points on everything but laser protection. (Old: 80 protection and +20 laser -> New: 90 protection and +10 laser) 
- Removed armor down/up tokens on base T-45d armor (No more melee +10 and laser -10; it's base now. 90 effective health and +10 effective health on laser.)
- Adjusts salvaged PA base variant to no longer give bonus armor tokens (So it's 80 protection proper now and +10 laser)
- Adjusts all PA and salvaged helmets to reflect their armor values proper for the most part.
- Removes head scribe's double-loadout. Not.. a good idea to give them round start AMRs + their other loadouts atop of it. Ever..
- Removes salvaged PA from shield head scribe loadout. Replaces with combat RCD; basically just a better RCD that can't be re-produced.
- Adds AER-9 and AEP-7 blueprints to sword head scribe since people complained they don't get an extra gun. Congrats, instead you get to make 2 weapons 'worse' than the Wattz2k but much cheaper + have their own niches.
- Adds AEP-7 blueprint to senior sword scribe since they only got an AER-9 blueprint. See same reason as Head Scribe.
- Repaths loadout selection field scribe coat to the PROPER light armor coat, not the 'fashion' coat. Didn't touch the map file ones though, someone else has to fix that one I guess. (Scribe coat has bonus armor over the scribe _'suit'_ (coat = Fallout 4 pocketed one, suit = hoodie winter coat looking one) - basically you sacrifice a TINY bit of movement speed on the coat for extra armor vs the robes or suit which allow you higher mobility but less armor.)

## Pre-Merge Checklist
- [ ] You tested this on a local server.
- [ ] This code did not runtime during testing.
- [ ] You documented all of your changes.
<!-- Tick these after making the PR. -->

## Changelog
:cl:
fixes: See above description.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
