### PR TITLE
Radiation Grenade Removal

### DIFF
--- a/code/datums/components/crafting/recipes/recipes_explosives.dm
+++ b/code/datums/components/crafting/recipes/recipes_explosives.dm
@@ -280,7 +280,7 @@
 	always_available = FALSE
 	skill_needed = SKILL_REPAIR
 	skill_level = REGULAR_CHECK
-
+/*
 /datum/crafting_recipe/radgrenade
 	name = "Radiation Grenade"
 	result = /obj/item/grenade/f13/radiation
@@ -300,7 +300,7 @@
 	always_available = FALSE
 	skill_needed = SKILL_REPAIR
 	skill_level = REGULAR_CHECK
-
+*/
 /datum/crafting_recipe/flashbang
 	name = "Flashbang"
 	result = /obj/item/grenade/flashbang

--- a/code/game/objects/effects/spawners/f13lootdrop.dm
+++ b/code/game/objects/effects/spawners/f13lootdrop.dm
@@ -1680,7 +1680,6 @@ obj/effect/spawner/bundle/f13/combat_rifle
 				/obj/item/grenade/syndieminibomb/concussion,
 				/obj/item/grenade/plastic/c4,
 				/obj/item/grenade/empgrenade,
-				/obj/item/grenade/f13/radiation,
 				/obj/item/grenade/f13/frag,
 				/obj/effect/spawner/bundle/f13/grenadelauncher,
 				)
@@ -1689,7 +1688,6 @@ obj/effect/spawner/bundle/f13/combat_rifle
 	loot = list(
 				/obj/item/grenade/f13/plasma,
 				/obj/item/grenade/f13/incendiary,
-				/obj/item/grenade/f13/radiation,
 				/obj/item/grenade/plastic/x4,
 				/obj/item/grenade/stingbang/shred = 1,
 				/obj/effect/spawner/bundle/f13/rocketlauncher,


### PR DESCRIPTION
## About The Pull Request
RADIOACTIVE SOCIETY AND ITS FUTURE

Introduction

The Radiation Revolution and its consequences have been a disaster for the human race. They have greatly increased the life-expectancy of those of us who live in “advanced” factions, but they have destabilized society, have made life unfulfilling, have subjected human beings to mutations, have led to widespread genetic suffering (in the Third World factions to ghoulification as well) and have inflicted severe damage on the natural world. The continued development of technology will worsen the situation. It will certainly subject human beings to greater mutations and inflict greater damage on the natural world, it will probably lead to greater social disruption and psychological suffering, and it may lead to increased physical suffering even in “advanced” factions.

## Pre-Merge Checklist
- [ ] You tested this on a local server.
- [ ] This code did not runtime during testing.
- [ ] You documented all of your changes.
<!-- Tick these after making the PR. -->

## Changelog
:cl:
removes: radiation grenades
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
