### PR TITLE
explorer/vet legion 10mm sub loadout fix

### DIFF
--- a/code/modules/jobs/job_types/legion.dm
+++ b/code/modules/jobs/job_types/legion.dm
@@ -700,7 +700,7 @@ Weapons		Lever shotgun, Grease gun, Repeater carbines, Revolvers, simple guns al
 	suit_store = /obj/item/gun/ballistic/automatic/smg/smg10mm
 	glasses = /obj/item/clothing/glasses/sunglasses/big
 	backpack_contents = list(
-		/obj/item/ammo_box/magazine/m10mm = 2,
+		/obj/item/ammo_box/magazine/m10mm/smg = 3,
 		/obj/item/grenade/smokebomb = 1,
 		/obj/item/grenade/homemade/coffeepotbomb = 1,
 		/obj/item/restraints/legcuffs/bola/tactical = 1,
@@ -794,7 +794,7 @@ Weapons		Lever shotgun, Grease gun, Repeater carbines, Revolvers, simple guns al
 	suit_store = /obj/item/gun/ballistic/automatic/smg/smg10mm
 	backpack_contents = list(
 		/obj/item/twohanded/spear/lance = 1,
-		/obj/item/ammo_box/magazine/m10mm/adv/ext = 2,
+		/obj/item/ammo_box/magazine/m10mm/smg = 3,
 		/obj/item/reagent_containers/pill/patch/healpoultice = 2,
 		/obj/item/melee/onehanded/machete/gladius = 1,
 		)


### PR DESCRIPTION
## About The Pull Request
<!-- Write here -->
Currently the explorer 10mm loadout gives 2 10mm pistol mags instead of actual smg mags. Same for the vet legion loadout with 2 extended pistol mags. Pretty sure this is an oversight and makes the early game difficult when your ammo bench starts with no books and have to work with one usable mag in your gun until you get those books.

## Pre-Merge Checklist
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
<!-- Tick these after making the PR. -->

## Changelog
:cl:
fix: Adds the correct magazines for the explorer and vet legion loadouts for the 10mm submachine.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
