### PR TITLE
adds minigun kit / fixes kit namings (Heavy Trooper)

### DIFF
--- a/code/modules/jobs/job_types/ncr.dm
+++ b/code/modules/jobs/job_types/ncr.dm
@@ -801,8 +801,9 @@ Weapons		Service Rifle, Grease Gun, 9mm pistol, all good.
 	exp_requirements = 375
 
 	loadout_options = list(
-		/datum/outfit/loadout/shockht,	// Minigun
-		/datum/outfit/loadout/supportht, // R84
+		/datum/outfit/loadout/shockht,	// R84
+		/datum/outfit/loadout/supportht, // minigun
+		/datum/outfit/loadout/flamerht //flamethrower
 		)
 
 /datum/outfit/job/ncr/f13heavytrooper/post_equip(mob/living/carbon/human/H, visualsOnly = FALSE)
@@ -837,11 +838,18 @@ Weapons		Service Rifle, Grease Gun, 9mm pistol, all good.
 		/obj/item/melee/onehanded/knife/bayonet = 1,
 		)
 
-/datum/outfit/loadout/supportht
-	name = "Support Heavy Trooper"
+/datum/outfit/loadout/flamerht
+	name = "Flamer Heavy Trooper"
 	backpack_contents = list(
 		/obj/item/m2flamethrowertank = 1,
 		/obj/item/ammo_box/jerrycan = 1,
+		/obj/item/melee/onehanded/knife/bowie = 1,
+		)
+
+/datum/outfit/loadout/supportht
+	name = "Support Heavy Trooper"
+	backpack_contents = list(
+		/obj/item/minigunpackbal5mm = 1,
 		/obj/item/melee/onehanded/knife/bowie = 1,
 		)
 


### PR DESCRIPTION
## About The Pull Request
<!-- Write here -->
adds a minigun kit to the HT 
fixes some mistakes in HT code (wrong names)

why?
Miniguns are better balanced now
## Pre-Merge Checklist
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
<!-- Tick these after making the PR. -->

## Changelog
:cl:
add: Adds a minigun kit to the heavy trooper
tweak: tweaked heavy trooper kit descs
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
