### PR TITLE
Riot armor spawner fix/replacement

### DIFF
--- a/code/game/objects/effects/spawners/f13lootdrop.dm
+++ b/code/game/objects/effects/spawners/f13lootdrop.dm
@@ -372,7 +372,7 @@
 	name = "tier 4 armor"
 	loot = list(
 				/obj/effect/spawner/bundle/f13/armor/t45b_salvaged,
-				/obj/effect/spawner/bundle/f13/armor/riot
+				/obj/effect/spawner/bundle/f13/armor/riot,
 				/obj/effect/spawner/bundle/f13/armor/riot/police,
 				/obj/effect/spawner/bundle/f13/armor/combat/mk2,
 				/obj/effect/spawner/bundle/f13/armor/combat/mk2/dark,

--- a/code/game/objects/effects/spawners/f13lootdrop.dm
+++ b/code/game/objects/effects/spawners/f13lootdrop.dm
@@ -372,7 +372,8 @@
 	name = "tier 4 armor"
 	loot = list(
 				/obj/effect/spawner/bundle/f13/armor/t45b_salvaged,
-				/obj/effect/spawner/bundle/f13/armor/riot,
+				/obj/effect/spawner/bundle/f13/armor/riot/elite,
+				/obj/effect/spawner/bundle/f13/armor/riot/police,
 				/obj/effect/spawner/bundle/f13/armor/combat/mk2,
 				/obj/effect/spawner/bundle/f13/armor/combat/mk2/dark,
 				)
@@ -384,10 +385,17 @@
 				/obj/item/clothing/head/helmet/f13/heavy/salvaged_pa/t45b
 				)
 
-/obj/effect/spawner/bundle/f13/armor/riot
-	name = "riot armor spawner"
+/obj/effect/spawner/bundle/f13/armor/riot/elite
+	name = "elite riot armor spawner"
 	items = list(
-				/obj/item/clothing/suit/armor/heavy/riot/combat,
+				/obj/item/clothing/suit/armor/heavy/riot/elite,
+				/obj/item/clothing/head/helmet/f13/combat/rangerbroken
+				)
+
+/obj/effect/spawner/bundle/f13/armor/riot/police
+	name = "riot police armor spawner"
+	items = list(
+				/obj/item/clothing/suit/armor/heavy/riot/police,
 				/obj/item/clothing/head/helmet/f13/combat/rangerbroken
 				)
 

--- a/code/game/objects/effects/spawners/f13lootdrop.dm
+++ b/code/game/objects/effects/spawners/f13lootdrop.dm
@@ -372,7 +372,7 @@
 	name = "tier 4 armor"
 	loot = list(
 				/obj/effect/spawner/bundle/f13/armor/t45b_salvaged,
-				/obj/effect/spawner/bundle/f13/armor/riot/elite,
+				/obj/effect/spawner/bundle/f13/armor/riot
 				/obj/effect/spawner/bundle/f13/armor/riot/police,
 				/obj/effect/spawner/bundle/f13/armor/combat/mk2,
 				/obj/effect/spawner/bundle/f13/armor/combat/mk2/dark,
@@ -385,7 +385,7 @@
 				/obj/item/clothing/head/helmet/f13/heavy/salvaged_pa/t45b
 				)
 
-/obj/effect/spawner/bundle/f13/armor/riot/elite
+/obj/effect/spawner/bundle/f13/armor/riot
 	name = "elite riot armor spawner"
 	items = list(
 				/obj/item/clothing/suit/armor/heavy/riot/elite,


### PR DESCRIPTION
## About The Pull Request
<!-- Write here -->
Replaces the riot combat armor (missing sprite/icon in armored_heavy.dmi and armor_heavy.dmi) with workable ones, "elite riot gear" (same stats) and "riot police armor" (emphasis on bullet protection).

![image](https://github.com/Afterglow-Ss13/afterglow-ss13/assets/126647931/40ab4383-ad4a-4efc-aeef-a08870ea1d5a)
![image](https://github.com/Afterglow-Ss13/afterglow-ss13/assets/126647931/9336f2f4-90de-4134-8604-79be374ee4c8)
![image](https://github.com/Afterglow-Ss13/afterglow-ss13/assets/126647931/f91a7e10-5f3a-423d-bd12-f173400cec3a)

## Pre-Merge Checklist
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
<!-- Tick these after making the PR. -->

## Changelog
:cl:
tweak: Removes riot "combat body armor" with the elite riot gear and police riot gear into the loot spawn.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
