### PR TITLE
Remove Mindshield Pin Printing

### DIFF
--- a/code/modules/projectiles/pins.dm
+++ b/code/modules/projectiles/pins.dm
@@ -108,13 +108,13 @@
 			if(req_implant && I.type == req_implant)
 				return TRUE
 	return FALSE
-
+/*
 /obj/item/firing_pin/implant/mindshield
 	name = "mindshield firing pin"
 	desc = "This Security firing pin authorizes the weapon for only mindshield-implanted users."
 	icon_state = "firing_pin_loyalty"
 	req_implant = /obj/item/implant/mindshield
-
+*/
 /obj/item/firing_pin/implant/pindicate
 	name = "syndicate firing pin"
 	icon_state = "firing_pin_pindi"

--- a/code/modules/research/designs/weapon_designs.dm
+++ b/code/modules/research/designs/weapon_designs.dm
@@ -229,7 +229,7 @@
 	build_path = /obj/item/firing_pin/test_range
 	category = list("Firing Pins")
 	departmental_flags = DEPARTMENTAL_FLAG_SECURITY | DEPARTMENTAL_FLAG_SCIENCE
-
+/*
 /datum/design/pin_mindshield
 	name = "Mindshield Firing Pin"
 	desc = "This is a security firing pin which only authorizes users who are mindshield-implanted."
@@ -239,7 +239,7 @@
 	build_path = /obj/item/firing_pin/implant/mindshield
 	category = list("Firing Pins")
 	departmental_flags = DEPARTMENTAL_FLAG_SECURITY
-
+*/
 /datum/design/pin_explorer
 	name = "Outback Firing Pin"
 	desc = "This firing pin only shoots while ya ain't on station, fair dinkum!"

--- a/code/modules/research/techweb/nodes/weaponry_nodes.dm
+++ b/code/modules/research/techweb/nodes/weaponry_nodes.dm
@@ -13,7 +13,7 @@
 	display_name = "Advanced Weapon Development Technology"
 	description = "Our weapons are breaking the rules of reality by now."
 	prereq_ids = list("adv_engi", "weaponry")
-	design_ids = list("pin_loyalty", "ecp", "bullet_shield")
+	design_ids = list("ecp", "bullet_shield")
 	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 7500)
 /*
 /datum/techweb_node/electric_weapons


### PR DESCRIPTION
## About The Pull Request
Rebel's PR to remove mindshield pins apparently did not finish the job. This PR should finish the job. Putting into draft to see if the compiler finds anything that needs gone,

## Pre-Merge Checklist
- [ ] You tested this on a local server.
- [ ] This code did not runtime during testing.
- [ ] You documented all of your changes.
<!-- Tick these after making the PR. -->

## Changelog
:cl: Dova
Removes: Protolathe ability to print mindshield pins
/:cl: