### PR TITLE
Fixes Pristine Circuit Spawners

### DIFF
--- a/code/game/objects/effects/spawners/f13lootdrop.dm
+++ b/code/game/objects/effects/spawners/f13lootdrop.dm
@@ -2208,6 +2208,7 @@ obj/effect/spawner/bundle/f13/combat_rifle
 		/obj/item/advanced_crafting_components/assembly,
 		/obj/item/advanced_crafting_components/alloys,
 		/obj/item/ingot/adamantine, // Valuable for smithing
+		/obj/item/advanced_crafting_components/p_circuits = 2
 	)
 
 /obj/effect/spawner/lootdrop/f13/attachments


### PR DESCRIPTION
## About The Pull Request
Pristine Circuits, needed for PA restoration, have not been spawning for almost a week now. This fixes that. I take no responsibility, instead I blame the ungrateful players who did not report such things to me in Discord. Simple fix, should not cause any issues

## Pre-Merge Checklist
- [] You tested this on a local server.
- [] This code did not runtime during testing.
- [x] You documented all of your changes.
<!-- Tick these after making the PR. -->

## Changelog
:cl: Dova
fixes: Pristine circuits now actually spawn: go forth and repair power armor!
/:cl:
