### PR TITLE
Fixing Mutie NCR Recruits, Off-Duty and Rear Ech

### DIFF
--- a/code/modules/jobs/job_types/ncr.dm
+++ b/code/modules/jobs/job_types/ncr.dm
@@ -1428,6 +1428,7 @@ Weapons		Service Rifle, Grease Gun, 9mm pistol, all good.
 	selection_color = "#fff5cc"
 	display_order = JOB_DISPLAY_ORDER_TROOPER
 	outfit = /datum/outfit/job/ncr/f13conscript
+	smutant_outfit = /datum/outfit/smutant/ncr
 
 	loadout_options = list(
 		/datum/outfit/loadout/conscriptvarmint, // Service Rifle, Bayonet
@@ -1633,6 +1634,7 @@ Weapons		Service Rifle, Grease Gun, 9mm pistol, all good.
 	exp_type = EXP_TYPE_NCR
 	display_order = JOB_DISPLAY_ORDER_REAR_ECHELON
 	outfit = /datum/outfit/job/ncr/f13rearechelon
+	smutant_outfit = /datum/outfit/smutant/ncr
 	exp_requirements = 60
 
 	loadout_options = list( // ALL: Very limited blueprints
@@ -1699,6 +1701,7 @@ Weapons		Service Rifle, Grease Gun, 9mm pistol, all good.
 	exp_type = EXP_TYPE_NCR
 	display_order = JOB_DISPLAY_ORDER_NCR_OFF_DUTY
 	outfit = /datum/outfit/job/ncr/f13ncroffduty
+	smutant_outfit = /datum/outfit/smutant/ncr
 	exp_requirements = 0
 
 /datum/outfit/job/ncr/f13ncroffduty


### PR DESCRIPTION
## About The Pull Request

Makes it so that NCR Mutie Recruits, Rear-Ech and Off-Duties don't spawn naked.

## Pre-Merge Checklist
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
<!-- Tick these after making the PR. -->

## Changelog
:cl:
fix: fixed NCR Muties spawning naked
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
