### PR TITLE
Gives Sword Scribes Explosive and Gunsmithing books

### DIFF
--- a/code/modules/jobs/job_types/bos.dm
+++ b/code/modules/jobs/job_types/bos.dm
@@ -308,6 +308,9 @@ Head Scribe
 		/obj/item/book/granter/crafting_recipe/blueprint/wattz2k = 1,
 		/obj/item/book/granter/crafting_recipe/blueprint/aer9 = 1,
 		/obj/item/book/granter/crafting_recipe/blueprint/aep7 = 1,
+		/obj/item/book/granter/trait/explosives_advanced = 1,
+		/obj/item/book/granter/crafting_recipe/gunsmith_three = 1,
+		/obj/item/book/granter/crafting_recipe/gunsmith_four = 1,
 		)
 
 /datum/outfit/loadout/hshield
@@ -689,6 +692,8 @@ Senior Scribe
 		/obj/item/book/granter/crafting_recipe/blueprint/aep7 = 1,
 		/obj/item/gun/energy/laser/pistol=1,
 		/obj/item/stock_parts/cell/ammo/ec=2,
+		/obj/item/book/granter/trait/explosives_advanced = 1,
+		/obj/item/book/granter/crafting_recipe/gunsmith_three = 1,
 		)
 
 /datum/outfit/loadout/sshield
@@ -788,6 +793,8 @@ Scribe
 	backpack_contents = list(
 		/obj/item/clothing/accessory/bos/juniorscribe=1,
 		/obj/item/book/granter/crafting_recipe/blueprint/aep7 = 1,
+		/obj/item/book/granter/trait/explosives = 1,
+		/obj/item/book/granter/crafting_recipe/gunsmith_three = 1,
 		)
 
 /datum/outfit/loadout/swordb
@@ -795,6 +802,8 @@ Scribe
 	backpack_contents = list(
 		/obj/item/clothing/accessory/bos/scribe=1,
 		/obj/item/book/granter/crafting_recipe/blueprint/aep7 = 1,
+		/obj/item/book/granter/trait/explosives = 1,
+		/obj/item/book/granter/crafting_recipe/gunsmith_three = 1,
 		)
 
 /datum/outfit/loadout/shielda


### PR DESCRIPTION
## About The Pull Request
Exactly what it says on the title, right now, there's no reason to choose Sword Scribe over anything else.
## Pre-Merge Checklist
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
<!-- Tick these after making the PR. -->

## Changelog
:cl:
add: A reason to  play Sword Scribe
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
