### PR TITLE
Far-lands tribals heirloom

### DIFF
--- a/code/datums/traits/negative.dm
+++ b/code/datums/traits/negative.dm
@@ -86,6 +86,8 @@ GLOBAL_LIST_EMPTY(family_heirlooms)
 			heirloom_type = /obj/item/card/id/dogtag/MDfakepermit
 		if("Farmer")
 			heirloom_type = pick(/obj/item/hatchet, /obj/item/shovel/spade, /obj/item/toy/plush/beeplushie)
+		if("Far-Lands Tribals")
+			heirloom_type = pick(/obj/item/clothing/accessory/talisman, /obj/item/clothing/accessory/skullcodpiece/fake)
 		if("Janitor")
 			heirloom_type = /obj/item/mop
 		if("Security Officer")


### PR DESCRIPTION
## About The Pull Request
This PR basically makes it where if you spawn in as far-lands tribals your heirloom is either, tailsman or skullcodpiece face, that way it keeps the tribals more lore friendly then getting a random action figure or a deck of cards.

## Pre-Merge Checklist
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
<!-- Tick these after making the PR. -->

## Changelog
:cl:
add: negative trait is either talisman or skull codpiece fake for tribals.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
