### PR TITLE
Fixes the tribal base ladder

### DIFF
--- a/_maps/map_files/Tipton/Tipton-Surface-2.dmm
+++ b/_maps/map_files/Tipton/Tipton-Surface-2.dmm
@@ -32028,7 +32028,8 @@
 "pJU" = (
 /obj/structure/ladder/unbreakable{
 	icon_state = "manhole_open";
-	id = "tribalbase"
+	id = "tribalbase";
+	height = 2
 	},
 /turf/open/floor/plating/dirt,
 /area/f13/wasteland)

--- a/_maps/map_files/Tipton/Tipton-Underground-1.dmm
+++ b/_maps/map_files/Tipton/Tipton-Underground-1.dmm
@@ -14054,7 +14054,7 @@
 "lIu" = (
 /obj/structure/ladder/unbreakable{
 	id = "tribalbase";
-	level = 1
+	height = 1
 	},
 /turf/open/floor/f13/wood,
 /area/f13/caves)


### PR DESCRIPTION
## About The Pull Request
This PR fixes the tribal ladder so people can go up and down on the ladder.
![image](https://github.com/Afterglow-Ss13/afterglow-ss13/assets/29418371/17464a20-ea3a-41ac-9587-b9f06c420921)
![image](https://github.com/Afterglow-Ss13/afterglow-ss13/assets/29418371/cd972b72-7490-4da5-8149-187fbc0a2c2c)


## Pre-Merge Checklist
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
<!-- Tick these after making the PR. -->

## Changelog
:cl:
tweak: Two ladders one in the tribal base and one in the hut where tribals could come at.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
