### PR TITLE
Fixes recipes of rustwalker granter

### DIFF
--- a/code/game/objects/items/granters.dm
+++ b/code/game/objects/items/granters.dm
@@ -1296,7 +1296,7 @@
 
 /obj/item/book/granter/crafting_recipe/tribal/rustwalkers
 	name = "Rustwalkers traditions"
-	crafting_recipe_types = list(/datum/crafting_recipe/tribalwar/eighties/lightarmour, /datum/crafting_recipe/tribalwar/rustwalkers/armour, /datum/crafting_recipe/tribalwar/eighties/heavyarmour, /datum/crafting_recipe/tribalwar/rustwalkers/garb, /datum/crafting_recipe/tribalwar/rustwalkers/femalegarb,)
+	crafting_recipe_types = list(/datum/crafting_recipe/tribalwar/rustwalkers/lightarmour, /datum/crafting_recipe/tribalwar/rustwalkers/armour, /datum/crafting_recipe/tribalwar/rustwalkers/heavyarmour, /datum/crafting_recipe/tribalwar/rustwalkers/garb, /datum/crafting_recipe/tribalwar/rustwalkers/femalegarb,)
 
 /obj/item/book/granter/crafting_recipe/tribal/eighties
 	name = "Eighties traditions"


### PR DESCRIPTION
## About The Pull Request
This PR fixes the rustwalker granter book to get rustwalker gear not eighties.


## Pre-Merge Checklist
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
<!-- Tick these after making the PR. -->

## Changelog
:cl:
fix: Rustwalker book grants rustwalker recipes
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
