### PR TITLE
Fix: Wayfarer armors is locked behind trait

### DIFF
--- a/code/datums/components/crafting/recipes/recipes_tribal.dm
+++ b/code/datums/components/crafting/recipes/recipes_tribal.dm
@@ -469,7 +469,9 @@ datum/crafting_recipe/tribalwar/bone
 
 // Western' Wayfarers
 
-// Wayfarers
+/datum/crafting_recipe/tribalwar/wayfarers
+	always_available = FALSE
+
 /datum/crafting_recipe/tribalwar/wayfarers/lightarmour
 	name = "Wayfarers Light Armour"
 	result = /obj/item/clothing/suit/armor/light/tribal/westernwayfarer
@@ -477,6 +479,7 @@ datum/crafting_recipe/tribalwar/bone
 	reqs = list(/obj/item/stack/crafting/metalparts = 5,
 				/obj/item/stack/sheet/leather = 5,
 				/obj/item/stack/crafting/goodparts = 5)
+
 /datum/crafting_recipe/tribalwar/wayfarers/heavyarmor
 	name = "Wayfarers Heavy Armour"
 	result = /obj/item/clothing/suit/armor/heavy/tribal/westernwayfarer


### PR DESCRIPTION
## About The Pull Request
Wayfarer armor is locked behind the trait, before it was a bug and it was in for a few days, should be fixed now.

## Pre-Merge Checklist
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
<!-- Tick these after making the PR. -->

## Changelog
:cl:
tweak: Wayfarer crafting code
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
