### PR TITLE
Fix: Legion flags appear once more

### DIFF
--- a/code/game/objects/items/fallout13misc.dm
+++ b/code/game/objects/items/fallout13misc.dm
@@ -271,7 +271,7 @@
 		if(do_after(user, 60, target = src))
 			var/obj/item/stack/sheet/leather/H = I
 			if(H.use(1))
-				var/list/choices = list("Bandit", "Outlaw", "BOS", "BOS Snow", "Followers", "Followers Snow", "NCR", "NCR Snow", "Ripley", "Ripley Snow", "Great Khans")
+				var/list/choices = list("Bandit", "Outlaw", "BOS", "BOS Snow", "Followers", "Followers Snow", "NCR", "NCR Snow", "Legion", "Legion Snow", "Ripley", "Ripley Snow", "Great Khans")
 				var/flag = input("Please choose which faction flag you wish to create.") in choices
 				switch(flag)
 					if("Bandit")


### PR DESCRIPTION
## About The Pull Request
This PR is a fix towards; https://github.com/Afterglow-Ss13/afterglow-ss13/pull/316 Which was a bug fix from the other flags, yet however the legion were forgotten and should be back on the menu tonight.

## Pre-Merge Checklist
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
<!-- Tick these after making the PR. -->

## Changelog
:cl:
tweak: Flag code back with legion flags.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
