### PR TITLE
Adds Colour Mate to town in Tipton

### DIFF
--- a/_maps/map_files/Tipton/Tipton-Surface-2.dmm
+++ b/_maps/map_files/Tipton/Tipton-Surface-2.dmm
@@ -5054,6 +5054,10 @@
 /obj/structure/decoration/warning,
 /turf/closed/wall/f13/tunnel,
 /area/f13/underground/mountain)
+"cAP" = (
+/obj/machinery/gear_painter,
+/turf/open/floor/plating/dirt,
+/area/f13/klamat/powered)
 "cAW" = (
 /obj/structure/bed/mattress{
 	icon_state = "mattress2";
@@ -83069,7 +83073,7 @@ rjd
 vUv
 hjL
 uYZ
-uDT
+cAP
 vUv
 rxh
 uDT


### PR DESCRIPTION
## About The Pull Request
<!-- Write here -->
Simple PR, adding a Colour Mate to the town in Tipton. So non-faction players can still colour their armour without relying on spray cans that barely work.
## Pre-Merge Checklist
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
<!-- Tick these after making the PR. -->

## Changelog
:cl:
add: Added colour mate to town in tipton
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
