### PR TITLE
Fixes gamma gun projectile not dealing damage

### DIFF
--- a/code/modules/projectiles/projectile/beams.dm
+++ b/code/modules/projectiles/projectile/beams.dm
@@ -114,7 +114,7 @@
 	icon_state = "xray"
 	damage = 15 //makes it more useful against mobs
 	flag = "energy"
-	armour_penetration = 1 //it only does 5 damage.
+	armour_penetration = 0.85 //it only does 15 damage.
 	irradiate = 100 //incase friendly fire
 	range = 15
 	pass_flags = PASSTABLE | PASSGLASS | PASSGRILLE | PASSCLOSEDTURF

--- a/code/modules/projectiles/projectile/beams.dm
+++ b/code/modules/projectiles/projectile/beams.dm
@@ -115,7 +115,6 @@
 	damage = 15 //makes it more useful against mobs
 	flag = "energy"
 	armour_penetration = 1 //it only does 5 damage.
-	damage_type = "burn"
 	irradiate = 100 //incase friendly fire
 	range = 15
 	pass_flags = PASSTABLE | PASSGLASS | PASSGRILLE | PASSCLOSEDTURF


### PR DESCRIPTION
Fixes invalid damage type on gamma gun projectile.

## About The Pull Request
Fixes the gamma gun projectile having an invalid damage type which prevented it from dealing damage.

## Pre-Merge Checklist
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
<!-- Tick these after making the PR. -->

## Changelog
:cl:
fix: Fixed invalid damage type on gamma gun projectile preventing it from dealing damage.
/:cl:
