### PR TITLE
Map Adjustments: DNA Manipulator Town Gone and syndicate toolbox too

### DIFF
--- a/_maps/map_files/Tipton/Tipton-Surface-2.dmm
+++ b/_maps/map_files/Tipton/Tipton-Surface-2.dmm
@@ -8617,12 +8617,6 @@
 /obj/structure/fence/wooden,
 /turf/open/floor/plating/dirt,
 /area/f13/wasteland)
-"elL" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/plantgenes,
-/turf/open/floor/f13/wood,
-/area/f13/klamat/powered)
 "emq" = (
 /obj/effect/turf_decal/weather/snow/corner,
 /obj/effect/spawner/lootdrop/trash,
@@ -41290,8 +41284,6 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/table,
-/obj/item/storage/box/disks_plantgene,
-/obj/item/storage/box/disks_plantgene,
 /turf/open/floor/f13/wood,
 /area/f13/klamat/powered)
 "ulf" = (
@@ -90722,7 +90714,7 @@ vLu
 mIf
 fWN
 fWN
-elL
+xUn
 toB
 oCz
 tjt

--- a/_maps/map_files/Tipton/Tipton-Underground-1.dmm
+++ b/_maps/map_files/Tipton/Tipton-Underground-1.dmm
@@ -2557,11 +2557,6 @@
 /obj/effect/spawner/lootdrop/bedsheet,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/sewer/powered)
-"cdO" = (
-/obj/item/storage/trash_stack,
-/obj/item/storage/toolbox/syndicate,
-/turf/open/indestructible/ground/inside/mountain,
-/area/f13/radiation)
 "cdQ" = (
 /obj/machinery/telecomms/server/presets/engineering,
 /turf/open/floor/plasteel/dark/telecomms/mainframe,
@@ -101474,7 +101469,7 @@ lux
 tYm
 tYm
 dtK
-cdO
+dAp
 fCT
 tYm
 tYm


### PR DESCRIPTION
## About The Pull Request
This PR nukes the towns dna manipulator and makes it where they gotta interact with the vault to get it, and syndicate toolbox from the sewers

## Pre-Merge Checklist
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
<!-- Tick these after making the PR. -->

## Changelog
:cl:
remove: dna manipulator from town and synie toolbox from sewers.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
