### PR TITLE
Addition Negative Trait: Deafness

### DIFF
--- a/code/datums/brain_damage/severe.dm
+++ b/code/datums/brain_damage/severe.dm
@@ -20,6 +20,21 @@
 	REMOVE_TRAIT(owner, TRAIT_MUTE, TRAUMA_TRAIT)
 	..()
 
+/datum/brain_trauma/severe/deaf
+	name = "Deaf"
+	desc = "Patient is completely unable to hear."
+	scan_desc = "extensive damage to the ears"
+	gain_text = span_warning("You forget how to hear!")
+	lose_text = span_notice("You suddenly remember how to hear.")
+
+/datum/brain_trauma/severe/deaf/on_gain()
+	ADD_TRAIT(owner, TRAIT_DEAF, TRAUMA_TRAIT)
+	..()
+
+/datum/brain_trauma/severe/deaf/on_lose()
+	REMOVE_TRAIT(owner, TRAIT_DEAF, TRAUMA_TRAIT)
+	..()
+
 /datum/brain_trauma/severe/aphasia
 	name = "Aphasia"
 	desc = "Patient is unable to speak or understand any language."

--- a/code/datums/traits/negative.dm
+++ b/code/datums/traits/negative.dm
@@ -554,6 +554,24 @@ Edit: TK~  This is the dumbest fucking shit I've ever seen in my life.  This isn
 	var/mob/living/carbon/human/H = quirk_holder
 	H?.cure_trauma_type(mute, TRAUMA_RESILIENCE_ABSOLUTE)
 
+/datum/quirk/deaf
+	name = "Deaf"
+	desc = "Due to some accident, medical condition or simply by explosion. You are simply completely unable to hear."
+	value = -2 // You are deaf. Not a license to grief.
+	gain_text = span_danger("You find yourself unable to ear at all!")
+	lose_text = span_notice("You somehow can hear again, even the slight sound of the wind.")
+	medical_record_text = "Functionally deaf, patient is unable to hear."
+
+/datum/quirk/deaf/post_add()
+	. = ..()
+	var/mob/living/carbon/human/H = quirk_holder
+	H.gain_trauma(/datum/brain_trauma/severe/deaf, TRAUMA_RESILIENCE_ABSOLUTE)
+
+/datum/quirk/deaf/remove()
+	. = ..()
+	var/mob/living/carbon/human/H = quirk_holder
+	H?.cure_trauma_type(/datum/brain_trauma/severe/deaf, TRAUMA_RESILIENCE_ABSOLUTE)
+
 /datum/quirk/unstable
 	name = "Unstable"
 	desc = "Due to past troubles, you are unable to recover your sanity if you lose it. Be very careful managing your mood!"


### PR DESCRIPTION
## About The Pull Request
This is a negative trait that should of been added a long time ago, this negative trait shouldnt be a license to grief but for rp'ers to rp as a deaf character and try the way to survive in the wasteland.
Ports deaf from: https://github.com/AtomBombf13/AtomBomb/pull/156
## Pre-Merge Checklist
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
<!-- Tick these after making the PR. -->

## Changelog
:cl:
add: Deafness to traits and adds severe deafness.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
