### PR TITLE
Map Fixes + Additions: Geckos

### DIFF
--- a/_maps/map_files/Tipton/Tipton-Sky-3.dmm
+++ b/_maps/map_files/Tipton/Tipton-Sky-3.dmm
@@ -6523,6 +6523,17 @@
 	},
 /turf/open/floor/plating/f13/outside/roof,
 /area/f13/wasteland)
+"xs" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/mob/living/simple_animal/hostile/gecko{
+	butcher_results = list(/mob/living/simple_animal/hostile/gecko=2);
+	color = "#fcba03";
+	desc = "A large mutated reptile with golden hide, sharp teeth and a kind-natured attitude. These creatures are rare up here - it seems it's seeking out warmth.";
+	faction = list("neutral","Legion");
+	name = "gackles"
+	},
+/turf/open/floor/wood_common,
+/area/f13/legioncamp)
 "xt" = (
 /obj/effect/turf_decal/weather/snow/corner{
 	dir = 9
@@ -80962,7 +80973,7 @@ LI
 VS
 uh
 EX
-uh
+xs
 uh
 uh
 TH

--- a/_maps/map_files/Tipton/Tipton-Surface-2.dmm
+++ b/_maps/map_files/Tipton/Tipton-Surface-2.dmm
@@ -12948,7 +12948,7 @@
 	butcher_results = list(/mob/living/simple_animal/hostile/gecko=2);
 	color = "#fcba03";
 	desc = "A large mutated reptile with golden hide, sharp teeth and a kind-natured attitude. These creatures are rare up here - it seems it's seeking out warmth.";
-	faction = list("neutral");
+	faction = list("neutral","BOS");
 	name = "gockles"
 	},
 /turf/open/floor/f13{
@@ -20825,7 +20825,7 @@
 	butcher_results = list(/mob/living/simple_animal/hostile/gecko=2);
 	color = "#fcba03";
 	desc = "A large mutated reptile with golden hide, sharp teeth and a kind-natured attitude. These creatures are rare up here - it seems it's seeking out warmth.";
-	faction = list("neutral,NCR");
+	faction = list("neutral","NCR");
 	name = "guckles"
 	},
 /turf/open/indestructible/ground/inside/mountain,
@@ -28575,7 +28575,7 @@
 	butcher_results = list(/mob/living/simple_animal/hostile/gecko=2);
 	color = "#fcba03";
 	desc = "A large mutated reptile with golden hide, sharp teeth and a kind-natured attitude. These creatures are rare up here - it seems it's seeking out warmth.";
-	faction = list("neutral");
+	faction = list("neutral","Town","Followers");
 	name = "gickles"
 	},
 /turf/open/water,

--- a/_maps/map_files/Tipton/Tipton-Underground-1.dmm
+++ b/_maps/map_files/Tipton/Tipton-Underground-1.dmm
@@ -16842,7 +16842,7 @@
 	butcher_results = list(/mob/living/simple_animal/hostile/gecko=2);
 	color = "#fcba03";
 	desc = "A large mutated reptile with golden hide, sharp teeth and a kind-natured attitude. These creatures are rare up here - it seems it's seeking out warmth.";
-	faction = list("neutral");
+	faction = list("neutral","Raiders","Wastelander");
 	name = "geckles"
 	},
 /obj/effect/decal/cleanable/dirt,


### PR DESCRIPTION
## About The Pull Request
What this PR adds is basically fixes the geckos from attacking the NCR and other related factions. Gickles shouldnt attack the townies anymore and freak out. Gockles enjoys the brotherhood people again instead of attacking the dog. Guckles is finally friendly to wastelanders and NCR. Geckles is now friendly to raiders and wastelanders.
This also adds gackos back to the legion, which doesnt get attacked by legion NPCs. 

## Pre-Merge Checklist
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
<!-- Tick these after making the PR. -->

## Changelog
:cl:
tweak: geckos in strongdmm, that way they go berserk to others.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
