### PR TITLE
Next Dev Iteration

### DIFF
--- a/code/datums/mood_events/generic_positive_events.dm
+++ b/code/datums/mood_events/generic_positive_events.dm
@@ -39,6 +39,11 @@
 	mood_change = 2
 	timeout = 5 MINUTES
 
+/datum/mood_event/inspiring_speech
+	description = span_nicegreen("What a great speech!")
+	mood_change = 3
+	timeout = 10 MINUTES
+
 /*
 /datum/mood_event/pet_animal/add_effects(mob/animal)
 	description = span_nicegreen("\The [animal.name] is adorable! I can't stop petting [animal.p_them()]!")

--- a/code/modules/mob/living/living_skills.dm
+++ b/code/modules/mob/living/living_skills.dm
@@ -18,6 +18,8 @@
 	var/sneaking = FALSE
 	var/sneaking_cooldown = 0
 	var/highest_gun_or_energy_cache = 0
+	var/inspire_cooldown = 0
+	var/inspired = 0
 
 // -20 for an easy roll
 // -10 for difficulty on a 'normal' roll
@@ -208,3 +210,77 @@ mob/proc/getLuckModifier()
 
 /mob/living/proc/clear_cooldown()
 	sneaking_cooldown = FALSE
+
+/mob/living/carbon/human/verb/inspire()
+	set name = "Inspire"
+	set category = "IC"
+	if (inspire_cooldown)
+		to_chat(src, span_warning("You can't do that again so soon."))
+		return
+	if (!skill_check(SKILL_SPEECH, EASY_CHECK))
+		to_chat(src, span_warning("Your speeches probably aren't going to inspire anyone."))
+		return
+	var/choices = skill_check(SKILL_SPEECH, HARD_CHECK) ? list("Everyone in earshot", "One person") : list("One person")
+	var/how_many_to_inspire = input(src, "How many people do you wish to inspire?", "Inspire", null) as null|anything in choices
+
+	if (how_many_to_inspire != null)
+		var/special_in_question = input(src, "Which S.P.E.C.I.A.L are you trying to inspire?", "Inspire", "s") as anything in list("s","p","e","c","i","a","l")
+		var/speech_given = input(src, "Please type the speech you intend to give to inspire your choosen target(s). Keep in mind roleplaying standards.", "Inspire", "") as text
+		var/mob/living/carbon/targeted_mob = null
+		var/list/mob/living/carbon/peeps = list()
+		if (how_many_to_inspire == "One person")
+			var/list/mob/living/carbon/people = list()
+			for(var/mob/living/carbon/A  in oview(src))
+				people.Add(A)
+			targeted_mob = input(src, "Who are you talking to?", "Inspire") as mob in people
+			if (targeted_mob)
+				peeps = list(targeted_mob)
+			else
+				return
+		else if (how_many_to_inspire == "Everyone in earshot")
+			for (var/mob/living/carbon/A  in oview(src))
+				peeps.Add(A)
+		var/our_speech_skill = skill_value(SKILL_SPEECH)
+		var/bonus = round(our_speech_skill/30, 1)
+		if (do_inspire_for_targets(peeps, special_in_question, bonus))
+			say(speech_given, spans = list("hypnophrase"))
+		else
+			say(speech_given)
+
+/mob/living/proc/do_inspire_for_targets(list/mob/living/carbon/inpirees, special_in_question, bonus)
+	inspire_cooldown = TRUE
+	var/good_speech = skill_roll_kind(SKILL_SPEECH, DIFFICULTY_NORMAL)
+	addtimer(CALLBACK(src, /mob/living/proc/clear_inspire_cooldown), 20 MINUTES)
+	if (good_speech)
+		SEND_SIGNAL(src, COMSIG_ADD_MOOD_EVENT, "speech", /datum/mood_event/inspiring_speech)
+		for (var/mob/living/carbon/inspiree  in inpirees)
+			if (inspiree.inspired || inspiree == src)
+				return
+			SEND_SIGNAL(inspiree, COMSIG_ADD_MOOD_EVENT, "speech", /datum/mood_event/inspiring_speech)
+			inspiree.modify_special(bonus, special_in_question)
+			inspiree.inspired = TRUE
+			addtimer(CALLBACK(inspiree, /mob/living/proc/modify_special, (-bonus), special_in_question), 20 MINUTES)
+			addtimer(CALLBACK(src, /mob/living/proc/clear_inspired), 20 MINUTES)
+	return good_speech
+
+/mob/living/proc/clear_inspire_cooldown()
+	inspire_cooldown = FALSE
+
+/mob/living/proc/clear_inspired()
+	inspired = FALSE
+
+/mob/living/proc/modify_special(val, spec)
+	if ("s" == spec)
+		special_s += val
+	if ("p" == spec)
+		special_p += val
+	if ("e" == spec)
+		special_e += val
+	if ("c" == spec)
+		special_c += val
+	if ("i" == spec)
+		special_i += val
+	if ("a" == spec)
+		special_a += val
+	if ("l" == spec)
+		special_l += val


### PR DESCRIPTION
Inspirations, added a new skill verb for boosting your allies!
Mini feature inbound soon: **Inspire verb!**
**What does it do?**
It's effects can vary based on how many points you've put into speech:
- Unlocked at 35
- Increases a chosen special of the target by 1 at 35, 2 at 50 and 65, 3 at 80
- At 65 speech it can be used to inspire everyone in earshot of you; as if you were rallying a crowd
- It increases the mood of your target(s), You'll also receive said mood buff too.
- It'll give the message you say a special css animation in chat too so you can tell when someone has used the verb and succeeded
- Bonuses are given ***only if*** skill roll is passed.

**How does it work?**
It's in your IC tab, when you click it it'll give you some input prompts to follow along with, One of which will prompt you for the text input allowing you to write out your inspiring speech! (I'm looking forward to reading the good ones 😄 )

**Important things to remember**: It will not change stuff that is set when a character spawns, such as health totals. It will last for 20 minutes; and you can't be inspired by anyone else in the mean time. The person who has used the verb also can't use it again for the same period.